### PR TITLE
feat(auth): register JWT and user entity modules

### DIFF
--- a/apps/auth/src/auth/auth.module.ts
+++ b/apps/auth/src/auth/auth.module.ts
@@ -1,8 +1,25 @@
 import { Module } from '@nestjs/common';
+import { JwtModule } from '@nestjs/jwt';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
+import { User } from '../users/entities/user.entity';
 
 @Module({
+  imports: [
+    TypeOrmModule.forFeature([User]),
+    JwtModule.registerAsync({
+      imports: [ConfigModule],
+      useFactory: async (configService: ConfigService) => ({
+        secret: configService.get<string>('JWT_SECRET'),
+        signOptions: {
+          expiresIn: configService.get<string | number>('JWT_EXPIRES_IN'),
+        },
+      }),
+      inject: [ConfigService],
+    }),
+  ],
   controllers: [AuthController],
   providers: [AuthService]
 })


### PR DESCRIPTION
## Summary
- add TypeORM user repository access to the auth module
- configure the JWT module using configuration-based secrets

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df2c139510832bb5aec1957ae2aa09