### PR TITLE
feat(auth): hash passwords on user creation

### DIFF
--- a/apps/auth/src/users/users.module.ts
+++ b/apps/auth/src/users/users.module.ts
@@ -3,9 +3,10 @@ import { UsersService } from './users.service';
 import { UsersController } from './users.controller';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { User } from './entities/user.entity';
+import { ConfigModule } from '@nestjs/config';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([User])],
+  imports: [TypeOrmModule.forFeature([User]), ConfigModule],
   controllers: [UsersController],
   providers: [UsersService],
   exports: [UsersService, TypeOrmModule],


### PR DESCRIPTION
## Summary
- hash user passwords within the users service before persisting new accounts
- reuse ConfigService-driven bcrypt configuration and avoid storing raw passwords
- register ConfigModule in the users module to provide required dependencies

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df32c1b4e4832bad62fa39f46f6ed0