### PR TITLE
feat: connect API gateway to auth microservice over TCP

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -38,7 +38,8 @@
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
     "swagger-ui-express": "^5.0.1",
-    "typeorm": "^0.3.27"
+    "typeorm": "^0.3.27",
+    "@nestjs/microservices": "^11.1.6"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -1,18 +1,20 @@
 import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { HealthModule } from './health/health.module';
-import { ConfigModule } from '@nestjs/config';
+import { AuthModule } from './auth/auth.module';
 
 @Module({
   imports: [
-    HealthModule,
     ConfigModule.forRoot({
       isGlobal: true,
       envFilePath: ['.env'],
     }),
+    AuthModule,
+    HealthModule,
   ],
   controllers: [AppController],
   providers: [AppService],
 })
-export class AppModule { }
+export class AppModule {}

--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -1,0 +1,24 @@
+import { Body, Controller, HttpCode, HttpStatus, Post } from '@nestjs/common';
+import { ApiCreatedResponse, ApiOkResponse, ApiTags } from '@nestjs/swagger';
+import { AuthService } from './auth.service';
+import { LoginDto, RegisterDto } from './dto';
+
+@ApiTags('auth')
+@Controller('auth')
+export class AuthController {
+  constructor(private readonly authService: AuthService) {}
+
+  @Post('register')
+  @HttpCode(HttpStatus.CREATED)
+  @ApiCreatedResponse({ description: 'User registered successfully' })
+  register(@Body() dto: RegisterDto) {
+    return this.authService.register(dto);
+  }
+
+  @Post('login')
+  @HttpCode(HttpStatus.OK)
+  @ApiOkResponse({ description: 'User authenticated successfully' })
+  login(@Body() dto: LoginDto) {
+    return this.authService.login(dto);
+  }
+}

--- a/apps/api/src/auth/auth.module.ts
+++ b/apps/api/src/auth/auth.module.ts
@@ -1,0 +1,30 @@
+import { Module } from '@nestjs/common';
+import { ClientsModule, Transport } from '@nestjs/microservices';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { AuthController } from './auth.controller';
+import { AuthService } from './auth.service';
+
+export const AUTH_SERVICE = Symbol('AUTH_SERVICE');
+
+@Module({
+  imports: [
+    ConfigModule,
+    ClientsModule.registerAsync([
+      {
+        name: AUTH_SERVICE,
+        inject: [ConfigService],
+        useFactory: (config: ConfigService) => ({
+          transport: Transport.TCP,
+          options: {
+            host: config.get<string>('AUTH_SERVICE_HOST', '127.0.0.1'),
+            port: Number(config.get<number>('AUTH_SERVICE_PORT', 4010)),
+          },
+        }),
+      },
+    ]),
+  ],
+  controllers: [AuthController],
+  providers: [AuthService],
+  exports: [AuthService],
+})
+export class AuthModule {}

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -1,0 +1,25 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { ClientProxy } from '@nestjs/microservices';
+import { lastValueFrom } from 'rxjs';
+import { AUTH_SERVICE } from './auth.module';
+import { LoginDto, RegisterDto } from './dto';
+
+@Injectable()
+export class AuthService {
+  constructor(
+    @Inject(AUTH_SERVICE)
+    private readonly authClient: ClientProxy,
+  ) {}
+
+  register(dto: RegisterDto) {
+    return lastValueFrom(this.authClient.send('register', dto));
+  }
+
+  login(dto: LoginDto) {
+    return lastValueFrom(this.authClient.send('login', dto));
+  }
+
+  ping() {
+    return lastValueFrom(this.authClient.send('ping', {}));
+  }
+}

--- a/apps/api/src/auth/dto/index.ts
+++ b/apps/api/src/auth/dto/index.ts
@@ -1,0 +1,2 @@
+export * from './login.dto';
+export * from './register.dto';

--- a/apps/api/src/auth/dto/login.dto.ts
+++ b/apps/api/src/auth/dto/login.dto.ts
@@ -1,0 +1,14 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString, MinLength } from 'class-validator';
+
+export class LoginDto {
+  @ApiProperty({ example: 'player@junglegaming.dev' })
+  @IsString()
+  @IsNotEmpty()
+  username!: string;
+
+  @ApiProperty({ example: 'changeme', minLength: 6 })
+  @IsString()
+  @MinLength(6)
+  password!: string;
+}

--- a/apps/api/src/auth/dto/register.dto.ts
+++ b/apps/api/src/auth/dto/register.dto.ts
@@ -1,0 +1,18 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEmail, IsNotEmpty, IsString, MinLength } from 'class-validator';
+
+export class RegisterDto {
+  @ApiProperty({ example: 'player@junglegaming.dev' })
+  @IsEmail()
+  email!: string;
+
+  @ApiProperty({ example: 'Player One' })
+  @IsString()
+  @IsNotEmpty()
+  name!: string;
+
+  @ApiProperty({ example: 'changeme', minLength: 6 })
+  @IsString()
+  @MinLength(6)
+  password!: string;
+}

--- a/apps/api/src/health/health.controller.spec.ts
+++ b/apps/api/src/health/health.controller.spec.ts
@@ -1,5 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { HealthController } from './health.controller';
+import { HealthService } from './health.service';
 
 describe('HealthController', () => {
   let controller: HealthController;
@@ -7,6 +8,12 @@ describe('HealthController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [HealthController],
+      providers: [
+        {
+          provide: HealthService,
+          useValue: { check: jest.fn() },
+        },
+      ],
     }).compile();
 
     controller = module.get<HealthController>(HealthController);

--- a/apps/api/src/health/health.controller.ts
+++ b/apps/api/src/health/health.controller.ts
@@ -1,13 +1,15 @@
 import { Controller, Get } from '@nestjs/common';
 import { ApiOkResponse, ApiTags } from '@nestjs/swagger';
+import { HealthService } from './health.service';
 
 @ApiTags('health')
 @Controller('health')
 export class HealthController {
+  constructor(private readonly healthService: HealthService) {}
 
-    @Get()
-    @ApiOkResponse({ description: 'Healthcheck OK' })
-    ping() {
-        return { status: 'ok', ts: new Date().toISOString() };
-    }
+  @Get()
+  @ApiOkResponse({ description: 'Aggregated healthcheck including microservices status' })
+  check() {
+    return this.healthService.check();
+  }
 }

--- a/apps/api/src/health/health.module.ts
+++ b/apps/api/src/health/health.module.ts
@@ -1,7 +1,11 @@
 import { Module } from '@nestjs/common';
 import { HealthController } from './health.controller';
+import { HealthService } from './health.service';
+import { AuthModule } from '../auth/auth.module';
 
 @Module({
-  controllers: [HealthController]
+  imports: [AuthModule],
+  controllers: [HealthController],
+  providers: [HealthService],
 })
 export class HealthModule {}

--- a/apps/api/src/health/health.service.ts
+++ b/apps/api/src/health/health.service.ts
@@ -1,0 +1,75 @@
+import { Injectable } from '@nestjs/common';
+import { AuthService } from '../auth/auth.service';
+
+type DependencyHealth<T = unknown> = {
+  status: 'ok' | 'error';
+  latencyMs: number;
+  details?: T;
+  error?: string;
+};
+
+@Injectable()
+export class HealthService {
+  constructor(private readonly authService: AuthService) {}
+
+  async check() {
+    const now = new Date().toISOString();
+
+    const dependencies = {
+      auth: await this.probe(() => this.authService.ping()),
+    } satisfies Record<string, DependencyHealth>;
+
+    const degraded = Object.values(dependencies).some(
+      (dependency) => dependency.status === 'error',
+    );
+
+    return {
+      status: degraded ? 'degraded' : 'ok',
+      ts: now,
+      services: {
+        gateway: {
+          status: 'ok' as const,
+          latencyMs: 0,
+          details: { ts: now },
+        },
+        ...dependencies,
+      },
+    };
+  }
+
+  private async probe<T>(factory: () => Promise<T>): Promise<DependencyHealth<T>> {
+    const startedAt = process.hrtime.bigint();
+
+    try {
+      const details = await factory();
+      return {
+        status: 'ok',
+        latencyMs: this.calculateLatency(startedAt),
+        details,
+      };
+    } catch (error) {
+      return {
+        status: 'error',
+        latencyMs: this.calculateLatency(startedAt),
+        error: this.extractErrorMessage(error),
+      };
+    }
+  }
+
+  private calculateLatency(startedAt: bigint) {
+    const diff = Number(process.hrtime.bigint() - startedAt);
+    return diff / 1_000_000; // ns -> ms
+  }
+
+  private extractErrorMessage(error: unknown) {
+    if (error instanceof Error) {
+      return error.message;
+    }
+
+    if (typeof error === 'object' && error !== null && 'message' in error) {
+      return String((error as { message?: unknown }).message);
+    }
+
+    return 'unknown error';
+  }
+}

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -1,13 +1,21 @@
+import { Logger, ValidationPipe } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
-import { AppModule } from './app.module';
-import { Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+import { AppModule } from './app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
 
   const config = app.get(ConfigService);
+
+  app.useGlobalPipes(
+    new ValidationPipe({
+      whitelist: true,
+      transform: true,
+      forbidNonWhitelisted: true,
+    }),
+  );
 
   const origin = config.get<string>('CORS_ORIGIN', '*');
 
@@ -19,18 +27,19 @@ async function bootstrap() {
     credentials: true,
   });
 
-  // Swagger placeholder
   const docConfig = new DocumentBuilder()
     .setTitle('Jungle Tasks — API Gateway')
-    .setDescription('Placeholder da documentação HTTP via Swagger')
+    .setDescription('HTTP entrypoint for Jungle microservices')
     .setVersion('0.1.0')
     .addBearerAuth({ type: 'http', scheme: 'bearer', bearerFormat: 'JWT' })
     .build();
 
   const document = SwaggerModule.createDocument(app, docConfig);
   SwaggerModule.setup('/api/docs', app, document);
-await app.listen(process.env.PORT ?? 3001);
-  Logger.log(`API docs available at http://localhost:${process.env.PORT ?? 3003}/api/docs`);
 
+  const port = Number(config.get('PORT', 3001));
+  await app.listen(port);
+  Logger.log(`API running on http://localhost:${port}/api`);
+  Logger.log(`API docs available at http://localhost:${port}/api/docs`);
 }
 bootstrap();


### PR DESCRIPTION
## Summary
- add an auth module that proxies register/login calls from the gateway to the auth microservice over TCP
- expose DTO validations, Swagger metadata, and aggregated health reporting that checks the auth dependency
- tighten gateway bootstrap configuration with global validation and corrected port logging

## Testing
- pnpm -F api-gateway test -- --runTestsByPath src/health/health.controller.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68df33d44708832b88f08450fdb0eef5