### PR TITLE
fix(api): remove auth module circular dependency

### DIFF
--- a/apps/api/src/auth/auth.constants.ts
+++ b/apps/api/src/auth/auth.constants.ts
@@ -1,0 +1,1 @@
+export const AUTH_SERVICE = Symbol('AUTH_SERVICE');

--- a/apps/api/src/auth/auth.module.ts
+++ b/apps/api/src/auth/auth.module.ts
@@ -3,8 +3,7 @@ import { ClientsModule, Transport } from '@nestjs/microservices';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
-
-export const AUTH_SERVICE = Symbol('AUTH_SERVICE');
+import { AUTH_SERVICE } from './auth.constants';
 
 @Module({
   imports: [

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -1,7 +1,7 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { ClientProxy } from '@nestjs/microservices';
 import { lastValueFrom } from 'rxjs';
-import { AUTH_SERVICE } from './auth.module';
+import { AUTH_SERVICE } from './auth.constants';
 import { LoginDto, RegisterDto } from './dto';
 
 @Injectable()


### PR DESCRIPTION
## Summary
- extract the AUTH_SERVICE token into a dedicated constants file for the API auth module
- update the auth module and service to consume the shared token without re-importing each other, eliminating the circular reference

## Testing
- pnpm --filter api-gateway build *(fails: TypeScript cannot find the @nestjs/microservices module types in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df3c0c86f8832b9fd3525e96affd15