### PR TITLE
feat: add auth contracts package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ dist/
 *.log
 coverage/
 
+*.tsbuildinfo

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -39,7 +39,8 @@
     "rxjs": "^7.8.1",
     "swagger-ui-express": "^5.0.1",
     "typeorm": "^0.3.27",
-    "@nestjs/microservices": "^11.1.6"
+    "@nestjs/microservices": "^11.1.6",
+    "@repo/contracts": "workspace:*"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",

--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -2,6 +2,7 @@ import { Body, Controller, HttpCode, HttpStatus, Post } from '@nestjs/common';
 import { ApiCreatedResponse, ApiOkResponse, ApiTags } from '@nestjs/swagger';
 import { AuthService } from './auth.service';
 import { LoginDto, RegisterDto } from './dto';
+import type { AuthLoginResponse, AuthRegisterResponse } from '@repo/contracts';
 
 @ApiTags('auth')
 @Controller('auth')
@@ -11,14 +12,14 @@ export class AuthController {
   @Post('register')
   @HttpCode(HttpStatus.CREATED)
   @ApiCreatedResponse({ description: 'User registered successfully' })
-  register(@Body() dto: RegisterDto) {
+  register(@Body() dto: RegisterDto): Promise<AuthRegisterResponse> {
     return this.authService.register(dto);
   }
 
   @Post('login')
   @HttpCode(HttpStatus.OK)
   @ApiOkResponse({ description: 'User authenticated successfully' })
-  login(@Body() dto: LoginDto) {
+  login(@Body() dto: LoginDto): Promise<AuthLoginResponse> {
     return this.authService.login(dto);
   }
 }

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -3,6 +3,12 @@ import { ClientProxy } from '@nestjs/microservices';
 import { lastValueFrom } from 'rxjs';
 import { AUTH_SERVICE } from './auth.constants';
 import { LoginDto, RegisterDto } from './dto';
+import { AUTH_MESSAGE_PATTERNS } from '@repo/contracts';
+import type {
+  AuthLoginResponse,
+  AuthPingResponse,
+  AuthRegisterResponse,
+} from '@repo/contracts';
 
 @Injectable()
 export class AuthService {
@@ -12,14 +18,20 @@ export class AuthService {
   ) {}
 
   register(dto: RegisterDto) {
-    return lastValueFrom(this.authClient.send('register', dto));
+    return lastValueFrom<AuthRegisterResponse>(
+      this.authClient.send(AUTH_MESSAGE_PATTERNS.REGISTER, dto),
+    );
   }
 
   login(dto: LoginDto) {
-    return lastValueFrom(this.authClient.send('login', dto));
+    return lastValueFrom<AuthLoginResponse>(
+      this.authClient.send(AUTH_MESSAGE_PATTERNS.LOGIN, dto),
+    );
   }
 
   ping() {
-    return lastValueFrom(this.authClient.send('ping', {}));
+    return lastValueFrom<AuthPingResponse>(
+      this.authClient.send(AUTH_MESSAGE_PATTERNS.PING, {}),
+    );
   }
 }

--- a/apps/api/src/auth/dto/login.dto.ts
+++ b/apps/api/src/auth/dto/login.dto.ts
@@ -1,7 +1,8 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsNotEmpty, IsString, MinLength } from 'class-validator';
+import type { AuthLoginRequest } from '@repo/contracts';
 
-export class LoginDto {
+export class LoginDto implements AuthLoginRequest {
   @ApiProperty({ example: 'player@junglegaming.dev' })
   @IsString()
   @IsNotEmpty()

--- a/apps/api/src/auth/dto/register.dto.ts
+++ b/apps/api/src/auth/dto/register.dto.ts
@@ -1,7 +1,8 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsEmail, IsNotEmpty, IsString, MinLength } from 'class-validator';
+import type { AuthRegisterRequest } from '@repo/contracts';
 
-export class RegisterDto {
+export class RegisterDto implements AuthRegisterRequest {
   @ApiProperty({ example: 'player@junglegaming.dev' })
   @IsEmail()
   email!: string;

--- a/apps/api/src/health/health.service.ts
+++ b/apps/api/src/health/health.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { AuthService } from '../auth/auth.service';
+import type { AuthPingResponse } from '@repo/contracts';
 
 type DependencyHealth<T = unknown> = {
   status: 'ok' | 'error';
@@ -16,7 +17,7 @@ export class HealthService {
     const now = new Date().toISOString();
 
     const dependencies = {
-      auth: await this.probe(() => this.authService.ping()),
+      auth: await this.probe<AuthPingResponse>(() => this.authService.ping()),
     } satisfies Record<string, DependencyHealth>;
 
     const degraded = Object.values(dependencies).some(
@@ -37,7 +38,9 @@ export class HealthService {
     };
   }
 
-  private async probe<T>(factory: () => Promise<T>): Promise<DependencyHealth<T>> {
+  private async probe<T>(
+    factory: () => Promise<T>,
+  ): Promise<DependencyHealth<T>> {
     const startedAt = process.hrtime.bigint();
 
     try {

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -21,5 +21,8 @@
     "noImplicitAny": false,
     "strictBindCallApply": false,
     "noFallthroughCasesInSwitch": false
-  }
+  },
+  "references": [
+    { "path": "../../packages/contracts" }
+  ]
 }

--- a/apps/auth/package.json
+++ b/apps/auth/package.json
@@ -41,7 +41,8 @@
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
     "swagger-ui-express": "^5.0.1",
-    "typeorm": "^0.3.27"
+    "typeorm": "^0.3.27",
+    "@repo/contracts": "workspace:*"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",

--- a/apps/auth/src/auth/auth.controller.ts
+++ b/apps/auth/src/auth/auth.controller.ts
@@ -4,19 +4,23 @@ import { AuthService } from './auth.service';
 import { LoginDto } from './dto';
 import { MessagePattern, Payload } from '@nestjs/microservices';
 import { CreateUserDto } from 'src/users/dto/create-user.dto';
+import { AUTH_MESSAGE_PATTERNS } from '@repo/contracts';
+import type { AuthLoginResponse, AuthRegisterResponse } from '@repo/contracts';
 
 @ApiTags('auth')
 @Controller('auth')
 export class AuthController {
-  constructor(private readonly auth: AuthService) { }
+  constructor(private readonly auth: AuthService) {}
 
-  @MessagePattern('register')
-  register(@Payload() createUserDto: CreateUserDto) {
+  @MessagePattern(AUTH_MESSAGE_PATTERNS.REGISTER)
+  register(
+    @Payload() createUserDto: CreateUserDto,
+  ): Promise<AuthRegisterResponse> {
     return this.auth.register(createUserDto);
   }
 
-  @MessagePattern('login')
-  login(@Payload() dto: LoginDto) {
-    return this.auth.login(dto.username, dto.password);
+  @MessagePattern(AUTH_MESSAGE_PATTERNS.LOGIN)
+  login(@Payload() dto: LoginDto): Promise<AuthLoginResponse> {
+    return this.auth.login(dto);
   }
 }

--- a/apps/auth/src/auth/dto.ts
+++ b/apps/auth/src/auth/dto.ts
@@ -1,14 +1,33 @@
 import { IsEmail, IsNotEmpty, IsString, MinLength } from 'class-validator';
+import type {
+  AuthLoginRequest,
+  AuthRefreshRequest,
+  AuthRegisterRequest,
+} from '@repo/contracts';
 
-export class RegisterDto {
-  @IsEmail() email!: string;
-  @IsString() @MinLength(3) username!: string;
-  @IsString() @MinLength(6) password!: string;
+export class RegisterDto implements AuthRegisterRequest {
+  @IsEmail()
+  email!: string;
+
+  @IsString()
+  @IsNotEmpty()
+  name!: string;
+
+  @IsString()
+  @MinLength(6)
+  password!: string;
 }
-export class LoginDto {
-  @IsString() @IsNotEmpty() username!: string; // ou email
-  @IsString() @MinLength(6) password!: string;
+export class LoginDto implements AuthLoginRequest {
+  @IsString()
+  @IsNotEmpty()
+  username!: string; // ou email
+
+  @IsString()
+  @MinLength(6)
+  password!: string;
 }
-export class RefreshDto {
-  @IsString() @IsNotEmpty() refreshToken!: string;
+export class RefreshDto implements AuthRefreshRequest {
+  @IsString()
+  @IsNotEmpty()
+  refreshToken!: string;
 }

--- a/apps/auth/src/health/health.controller.ts
+++ b/apps/auth/src/health/health.controller.ts
@@ -1,13 +1,14 @@
-import { Controller } from "@nestjs/common";
-import { MessagePattern } from "@nestjs/microservices";
-import { ApiTags } from "@nestjs/swagger";
+import { Controller } from '@nestjs/common';
+import { MessagePattern } from '@nestjs/microservices';
+import { ApiTags } from '@nestjs/swagger';
+import { AUTH_MESSAGE_PATTERNS } from '@repo/contracts';
+import type { AuthPingResponse } from '@repo/contracts';
 
 @ApiTags('health')
 @Controller('health')
 export class HealthController {
-
-    @MessagePattern('ping')
-    ping() {
-        return { status: 'ok', ts: new Date().toISOString() };
-    }
+  @MessagePattern(AUTH_MESSAGE_PATTERNS.PING)
+  ping(): AuthPingResponse {
+    return { status: 'ok', ts: new Date().toISOString() };
+  }
 }

--- a/apps/auth/src/users/dto/create-user.dto.ts
+++ b/apps/auth/src/users/dto/create-user.dto.ts
@@ -1,27 +1,31 @@
-import { IsEmail, IsNotEmpty, IsString } from "class-validator";
+import { IsEmail, IsNotEmpty, IsString } from 'class-validator';
+import type { AuthRegisterRequest } from '@repo/contracts';
 
-export class CreateUserDto {
-    @IsString({
-        message: 'email must be a string'
-    })
-    @IsEmail({}, {
-        message: 'email must be a valid email address'
-    })
-    email: string;
+export class CreateUserDto implements AuthRegisterRequest {
+  @IsString({
+    message: 'email must be a string',
+  })
+  @IsEmail(
+    {},
+    {
+      message: 'email must be a valid email address',
+    },
+  )
+  email!: string;
 
-    @IsString({
-        message: 'name must be a string'
-    })
-    @IsNotEmpty({
-        message: 'name must not be empty'
-    })
-    name: string;
+  @IsString({
+    message: 'name must be a string',
+  })
+  @IsNotEmpty({
+    message: 'name must not be empty',
+  })
+  name!: string;
 
-    @IsString({
-        message: 'password must be a string'
-    })
-    @IsNotEmpty({
-        message: 'password must not be empty'
-    })
-    password: string;
+  @IsString({
+    message: 'password must be a string',
+  })
+  @IsNotEmpty({
+    message: 'password must not be empty',
+  })
+  password!: string;
 }

--- a/apps/auth/tsconfig.json
+++ b/apps/auth/tsconfig.json
@@ -21,5 +21,8 @@
     "noImplicitAny": false,
     "strictBindCallApply": false,
     "noFallthroughCasesInSwitch": false
-  }
+  },
+  "references": [
+    { "path": "../../packages/contracts" }
+  ]
 }

--- a/packages/contracts/eslint.config.mjs
+++ b/packages/contracts/eslint.config.mjs
@@ -1,0 +1,3 @@
+import { config } from "@repo/eslint-config/base";
+
+export default config;

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@repo/contracts",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./*": {
+      "types": "./dist/*.d.ts",
+      "default": "./dist/*.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "lint": "eslint . --ext .ts --max-warnings 0",
+    "check-types": "tsc --noEmit",
+    "prepare": "pnpm run build"
+  },
+  "devDependencies": {
+    "@repo/eslint-config": "workspace:*",
+    "@repo/typescript-config": "workspace:*",
+    "@types/node": "^22.15.3",
+    "eslint": "^9.34.0",
+    "typescript": "5.9.2"
+  }
+}

--- a/packages/contracts/src/auth/index.ts
+++ b/packages/contracts/src/auth/index.ts
@@ -1,0 +1,2 @@
+export * from './messages.js';
+export * from './schemas.js';

--- a/packages/contracts/src/auth/messages.ts
+++ b/packages/contracts/src/auth/messages.ts
@@ -1,0 +1,8 @@
+export const AUTH_MESSAGE_PATTERNS = {
+  REGISTER: 'auth.register',
+  LOGIN: 'auth.login',
+  PING: 'auth.ping',
+} as const;
+
+export type AuthMessagePattern =
+  (typeof AUTH_MESSAGE_PATTERNS)[keyof typeof AUTH_MESSAGE_PATTERNS];

--- a/packages/contracts/src/auth/schemas.ts
+++ b/packages/contracts/src/auth/schemas.ts
@@ -1,0 +1,35 @@
+export interface AuthUser {
+  id: string;
+  email: string;
+  name: string;
+}
+
+export interface AuthTokens {
+  access_token: string;
+}
+
+export interface AuthRegisterRequest {
+  email: string;
+  name: string;
+  password: string;
+}
+
+export interface AuthLoginRequest {
+  username: string;
+  password: string;
+}
+
+export interface AuthRefreshRequest {
+  refreshToken: string;
+}
+
+export interface AuthRegisterResponse extends AuthTokens {
+  user: AuthUser;
+}
+
+export type AuthLoginResponse = AuthRegisterResponse;
+
+export interface AuthPingResponse {
+  status: 'ok';
+  ts: string;
+}

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1,0 +1,1 @@
+export * from './auth/index.js';

--- a/packages/contracts/tsconfig.json
+++ b/packages/contracts/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "@repo/typescript-config/base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "declaration": true,
+    "emitDeclarationOnly": false,
+    "rootDir": "src",
+    "composite": true,
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "resolvePackageJsonExports": true,
+    "incremental": true
+  },
+  "include": ["src/**/*.ts", "src/**/*.d.ts"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       '@nestjs/jwt':
         specifier: ^11.0.0
         version: 11.0.0(@nestjs/common@11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))
+      '@nestjs/microservices':
+        specifier: ^11.1.6
+        version: 11.1.6(@nestjs/common@11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.6)(amqp-connection-manager@5.0.0(amqplib@0.10.9))(amqplib@0.10.9)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/passport':
         specifier: ^11.0.5
         version: 11.0.5(@nestjs/common@11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(passport@0.7.0)
@@ -47,6 +50,9 @@ importers:
       '@nestjs/typeorm':
         specifier: ^11.0.0
         version: 11.0.0(@nestjs/common@11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.6(@nestjs/common@11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/microservices@11.1.6)(@nestjs/platform-express@11.1.6)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)(typeorm@0.3.27(pg@8.16.3)(reflect-metadata@0.2.2)(ts-node@10.9.2(@types/node@22.15.3)(typescript@5.9.2)))
+      '@repo/contracts':
+        specifier: workspace:*
+        version: link:../../packages/contracts
       bcrypt:
         specifier: ^6.0.0
         version: 6.0.0
@@ -186,6 +192,9 @@ importers:
       '@nestjs/typeorm':
         specifier: ^11.0.0
         version: 11.0.0(@nestjs/common@11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.6(@nestjs/common@11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/microservices@11.1.6)(@nestjs/platform-express@11.1.6)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)(typeorm@0.3.27(pg@8.16.3)(reflect-metadata@0.2.2)(ts-node@10.9.2(@types/node@22.15.3)(typescript@5.9.2)))
+      '@repo/contracts':
+        specifier: workspace:*
+        version: link:../../packages/contracts
       amqp-connection-manager:
         specifier: ^5.0.0
         version: 5.0.0(amqplib@0.10.9)
@@ -441,6 +450,24 @@ importers:
       '@types/react-dom':
         specifier: 19.1.1
         version: 19.1.1(@types/react@19.1.0)
+      eslint:
+        specifier: ^9.34.0
+        version: 9.34.0
+      typescript:
+        specifier: 5.9.2
+        version: 5.9.2
+
+  packages/contracts:
+    devDependencies:
+      '@repo/eslint-config':
+        specifier: workspace:*
+        version: link:../eslint-config
+      '@repo/typescript-config':
+        specifier: workspace:*
+        version: link:../typescript-config
+      '@types/node':
+        specifier: ^22.15.3
+        version: 22.15.3
       eslint:
         specifier: ^9.34.0
         version: 9.34.0


### PR DESCRIPTION
## Summary
- add a new `@repo/contracts` workspace package exposing auth message patterns and typed request/response schemas for reuse
- update the auth service and API gateway to depend on the shared contracts, sanitize returned users, and adopt common message identifiers
- link the new contracts package in each service's TypeScript configuration so shared types participate in project builds

## Testing
- pnpm --filter @repo/contracts build
- pnpm --filter auth build
- pnpm --filter api-gateway build

------
https://chatgpt.com/codex/tasks/task_e_68dfca4d99e8832ba9b419fdf31e1bba