### PR TITLE
Handle RPC exceptions across auth services

### DIFF
--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -1,6 +1,6 @@
-import { Inject, Injectable } from '@nestjs/common';
-import { ClientProxy } from '@nestjs/microservices';
-import { lastValueFrom } from 'rxjs';
+import { HttpException, Inject, Injectable } from '@nestjs/common';
+import { ClientProxy, RpcException } from '@nestjs/microservices';
+import { catchError, lastValueFrom, throwError } from 'rxjs';
 import { AUTH_SERVICE } from './auth.constants';
 import { LoginDto, RegisterDto } from './dto';
 import { AUTH_MESSAGE_PATTERNS } from '@repo/contracts';
@@ -19,19 +19,41 @@ export class AuthService {
 
   register(dto: RegisterDto) {
     return lastValueFrom<AuthRegisterResponse>(
-      this.authClient.send(AUTH_MESSAGE_PATTERNS.REGISTER, dto),
+      this.authClient.send(AUTH_MESSAGE_PATTERNS.REGISTER, dto).pipe(
+        catchError((err) => this.handleRpcException(err)),
+      ),
     );
   }
 
   login(dto: LoginDto) {
     return lastValueFrom<AuthLoginResponse>(
-      this.authClient.send(AUTH_MESSAGE_PATTERNS.LOGIN, dto),
+      this.authClient.send(AUTH_MESSAGE_PATTERNS.LOGIN, dto).pipe(
+        catchError((err) => this.handleRpcException(err)),
+      ),
     );
   }
 
   ping() {
     return lastValueFrom<AuthPingResponse>(
-      this.authClient.send(AUTH_MESSAGE_PATTERNS.PING, {}),
+      this.authClient.send(AUTH_MESSAGE_PATTERNS.PING, {}).pipe(
+        catchError((err) => this.handleRpcException(err)),
+      ),
     );
+  }
+
+  private handleRpcException(error: unknown) {
+    if (error instanceof RpcException) {
+      const payload = error.getError() as {
+        statusCode?: number;
+        message?: string;
+      };
+      if (payload?.statusCode && payload?.message) {
+        return throwError(
+          () => new HttpException(payload.message, payload.statusCode),
+        );
+      }
+    }
+
+    return throwError(() => error);
   }
 }

--- a/apps/api/test/__mocks__/repo-contracts.ts
+++ b/apps/api/test/__mocks__/repo-contracts.ts
@@ -1,0 +1,5 @@
+export const AUTH_MESSAGE_PATTERNS = {
+  REGISTER: 'auth.register',
+  LOGIN: 'auth.login',
+  PING: 'auth.ping',
+};

--- a/apps/api/test/app.e2e-spec.ts
+++ b/apps/api/test/app.e2e-spec.ts
@@ -1,19 +1,31 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { INestApplication } from '@nestjs/common';
-import * as request from 'supertest';
+import { HttpStatus, INestApplication } from '@nestjs/common';
+import request from 'supertest';
 import { App } from 'supertest/types';
 import { AppModule } from './../src/app.module';
+import { AUTH_SERVICE } from '../src/auth/auth.constants';
+import { RpcException } from '@nestjs/microservices';
+import { throwError } from 'rxjs';
 
 describe('AppController (e2e)', () => {
   let app: INestApplication<App>;
+  let authClient: { send: jest.Mock };
 
   beforeEach(async () => {
+    authClient = { send: jest.fn() };
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [AppModule],
-    }).compile();
+    })
+      .overrideProvider(AUTH_SERVICE)
+      .useValue(authClient)
+      .compile();
 
     app = moduleFixture.createNestApplication();
     await app.init();
+  });
+
+  afterEach(async () => {
+    await app.close();
   });
 
   it('/ (GET)', () => {
@@ -21,5 +33,49 @@ describe('AppController (e2e)', () => {
       .get('/')
       .expect(200)
       .expect('Hello World!');
+  });
+
+  it('POST /auth/register returns 409 when email already exists', async () => {
+    authClient.send.mockReturnValueOnce(
+      throwError(
+        () =>
+          new RpcException({
+            statusCode: HttpStatus.CONFLICT,
+            message: 'email already in use',
+          }),
+      ),
+    );
+
+    await request(app.getHttpServer())
+      .post('/auth/register')
+      .send({
+        email: 'player@junglegaming.dev',
+        name: 'Player One',
+        password: 'secret1',
+      })
+      .expect(HttpStatus.CONFLICT)
+      .expect(({ body }) => {
+        expect(body.message).toBe('email already in use');
+      });
+  });
+
+  it('POST /auth/login returns 401 when credentials are invalid', async () => {
+    authClient.send.mockReturnValueOnce(
+      throwError(
+        () =>
+          new RpcException({
+            statusCode: HttpStatus.UNAUTHORIZED,
+            message: 'invalid credentials',
+          }),
+      ),
+    );
+
+    await request(app.getHttpServer())
+      .post('/auth/login')
+      .send({ username: 'player@junglegaming.dev', password: 'secret1' })
+      .expect(HttpStatus.UNAUTHORIZED)
+      .expect(({ body }) => {
+        expect(body.message).toBe('invalid credentials');
+      });
   });
 });

--- a/apps/api/test/jest-e2e.json
+++ b/apps/api/test/jest-e2e.json
@@ -5,5 +5,9 @@
   "testRegex": ".e2e-spec.ts$",
   "transform": {
     "^.+\\.(t|j)s$": "ts-jest"
+  },
+  "moduleNameMapper": {
+    "^@repo/contracts$": "<rootDir>/__mocks__/repo-contracts.ts",
+    "^@repo/contracts/(.*)$": "<rootDir>/__mocks__/repo-contracts/$1.ts"
   }
 }


### PR DESCRIPTION
## Summary
- translate auth microservice conflict/unauthorized errors into RpcExceptions with explicit status codes
- ensure the API gateway converts RpcException payloads to HttpExceptions before returning
- cover duplicate registration and invalid login scenarios with e2e tests that mock the auth client

## Testing
- pnpm --filter api-gateway test:e2e

------
https://chatgpt.com/codex/tasks/task_e_68dfe634597c832b9275ae0c647499cb