### PR TITLE
Add dev Dockerfiles and compose setup for apps

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.git
+node_modules
+**/node_modules
+pnpm-store
+.pnpm-store
+.DS_Store
+.vscode
+.env.local
+

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,0 +1,15 @@
+# syntax=docker/dockerfile:1.7
+
+FROM node:22-alpine AS base
+WORKDIR /workspace
+ENV PNPM_HOME="/pnpm"
+ENV PNPM_STORE_DIR="/pnpm/store"
+ENV PATH="$PNPM_HOME:$PATH"
+RUN corepack enable pnpm
+
+FROM base AS dev
+ENV NODE_ENV=development
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml turbo.json ./
+COPY packages ./packages
+COPY apps/api ./apps/api
+CMD ["pnpm", "--filter", "api-gateway...", "dev"]

--- a/apps/auth/Dockerfile
+++ b/apps/auth/Dockerfile
@@ -1,0 +1,15 @@
+# syntax=docker/dockerfile:1.7
+
+FROM node:22-alpine AS base
+WORKDIR /workspace
+ENV PNPM_HOME="/pnpm"
+ENV PNPM_STORE_DIR="/pnpm/store"
+ENV PATH="$PNPM_HOME:$PATH"
+RUN corepack enable pnpm
+
+FROM base AS dev
+ENV NODE_ENV=development
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml turbo.json ./
+COPY packages ./packages
+COPY apps/auth ./apps/auth
+CMD ["pnpm", "--filter", "auth...", "dev"]

--- a/apps/tasks/Dockerfile
+++ b/apps/tasks/Dockerfile
@@ -1,0 +1,15 @@
+# syntax=docker/dockerfile:1.7
+
+FROM node:22-alpine AS base
+WORKDIR /workspace
+ENV PNPM_HOME="/pnpm"
+ENV PNPM_STORE_DIR="/pnpm/store"
+ENV PATH="$PNPM_HOME:$PATH"
+RUN corepack enable pnpm
+
+FROM base AS dev
+ENV NODE_ENV=development
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml turbo.json ./
+COPY packages ./packages
+COPY apps/tasks ./apps/tasks
+CMD ["pnpm", "--filter", "tasks...", "dev"]

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,0 +1,16 @@
+# syntax=docker/dockerfile:1.7
+
+FROM node:22-alpine AS base
+WORKDIR /workspace
+ENV PNPM_HOME="/pnpm"
+ENV PNPM_STORE_DIR="/pnpm/store"
+ENV PATH="$PNPM_HOME:$PATH"
+RUN apk add --no-cache libc6-compat
+RUN corepack enable pnpm
+
+FROM base AS dev
+ENV NODE_ENV=development
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml turbo.json ./
+COPY packages ./packages
+COPY apps/web ./apps/web
+CMD ["pnpm", "--filter", "web...", "dev"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,9 +39,120 @@ services:
       timeout: 5s
       retries: 5
 
+  auth:
+    build:
+      context: .
+      dockerfile: apps/auth/Dockerfile
+      target: dev
+    container_name: auth-service-dev
+    command: >-
+      sh -c "pnpm install --filter auth... --frozen-lockfile && pnpm --filter auth... dev"
+    working_dir: /workspace
+    environment:
+      NODE_ENV: development
+      DATABASE_URL: postgres://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-password}@db:5432/${POSTGRES_DB:-challenge_db}
+      JWT_SECRET: ${JWT_SECRET:-supersecret}
+      JWT_EXPIRES_IN: ${JWT_EXPIRES_IN:-15m}
+      BCRYPT_SALT_ROUNDS: ${BCRYPT_SALT_ROUNDS:-10}
+    depends_on:
+      db:
+        condition: service_healthy
+    volumes:
+      - .:/workspace
+      - pnpm-store:/pnpm/store
+      - root-node-modules:/workspace/node_modules
+      - auth-node-modules:/workspace/apps/auth/node_modules
+    networks: [challenge-net]
+
+  api:
+    build:
+      context: .
+      dockerfile: apps/api/Dockerfile
+      target: dev
+    container_name: api-gateway-dev
+    command: >-
+      sh -c "pnpm install --filter api-gateway... --frozen-lockfile && pnpm --filter api-gateway... dev"
+    working_dir: /workspace
+    environment:
+      NODE_ENV: development
+      PORT: ${API_PORT:-3001}
+      AUTH_SERVICE_HOST: auth
+      AUTH_SERVICE_PORT: 4010
+      CORS_ORIGIN: ${CORS_ORIGIN:-http://localhost:3000}
+    depends_on:
+      db:
+        condition: service_healthy
+      auth:
+        condition: service_started
+    ports:
+      - "${API_PORT:-3001}:3001"
+    volumes:
+      - .:/workspace
+      - pnpm-store:/pnpm/store
+      - root-node-modules:/workspace/node_modules
+      - api-node-modules:/workspace/apps/api/node_modules
+    networks: [challenge-net]
+
+  tasks:
+    build:
+      context: .
+      dockerfile: apps/tasks/Dockerfile
+      target: dev
+    container_name: tasks-service-dev
+    command: >-
+      sh -c "pnpm install --filter tasks... --frozen-lockfile && pnpm --filter tasks... dev"
+    working_dir: /workspace
+    environment:
+      NODE_ENV: development
+      PORT: ${TASKS_PORT:-3003}
+      RABBITMQ_URL: amqp://${RABBITMQ_USER:-admin}:${RABBITMQ_PASS:-admin}@rabbitmq:5672
+      CORS_ORIGIN: ${CORS_ORIGIN:-http://localhost:3000}
+    depends_on:
+      rabbitmq:
+        condition: service_healthy
+    ports:
+      - "${TASKS_PORT:-3003}:3003"
+    volumes:
+      - .:/workspace
+      - pnpm-store:/pnpm/store
+      - root-node-modules:/workspace/node_modules
+      - tasks-node-modules:/workspace/apps/tasks/node_modules
+    networks: [challenge-net]
+
+  web:
+    build:
+      context: .
+      dockerfile: apps/web/Dockerfile
+      target: dev
+    container_name: web-app-dev
+    command: >-
+      sh -c "pnpm install --filter web... --frozen-lockfile && pnpm --filter web... dev"
+    working_dir: /workspace
+    environment:
+      NODE_ENV: development
+      PORT: ${WEB_PORT:-3000}
+      NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-http://localhost:3001/api}
+    depends_on:
+      api:
+        condition: service_started
+    ports:
+      - "${WEB_PORT:-3000}:3000"
+    volumes:
+      - .:/workspace
+      - pnpm-store:/pnpm/store
+      - root-node-modules:/workspace/node_modules
+      - web-node-modules:/workspace/apps/web/node_modules
+    networks: [challenge-net]
+
 volumes:
   postgres_data:
   rabbitmq_data:
+  pnpm-store:
+  root-node-modules:
+  auth-node-modules:
+  api-node-modules:
+  tasks-node-modules:
+  web-node-modules:
 
 networks:
   challenge-net:


### PR DESCRIPTION
## Summary
- add development-targeted Dockerfiles for the api, auth, tasks, and web applications
- configure docker-compose with shared network, volumes, and environment for the full stack including infrastructure services
- ignore node modules and tooling artifacts in Docker build contexts via a new .dockerignore

## Testing
- docker compose config *(fails in container: docker not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68dff2404f90832bbc9ff8e21f8a59c4