### PR TITLE
Add environment example files for services

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ node_modules/
 dist/
 .env
 .env.*
+!**/.env.example
 .DS_Store
 *.log
 coverage/

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,0 +1,6 @@
+# API Gateway environment variables
+NODE_ENV=development
+PORT=3001
+CORS_ORIGIN=http://localhost:3000
+AUTH_SERVICE_HOST=127.0.0.1
+AUTH_SERVICE_PORT=4010

--- a/apps/auth/.env.example
+++ b/apps/auth/.env.example
@@ -1,0 +1,6 @@
+# Authentication service environment variables
+NODE_ENV=development
+DATABASE_URL=postgres://postgres:password@localhost:5432/challenge_db
+JWT_SECRET=supersecret
+JWT_EXPIRES_IN=15m
+BCRYPT_SALT_ROUNDS=10

--- a/apps/notifications/.env.example
+++ b/apps/notifications/.env.example
@@ -1,0 +1,3 @@
+# Notifications service environment variables
+NODE_ENV=development
+PORT=3000

--- a/apps/tasks/.env.example
+++ b/apps/tasks/.env.example
@@ -1,0 +1,5 @@
+# Tasks service environment variables
+NODE_ENV=development
+PORT=3003
+CORS_ORIGIN=http://localhost:3000
+RABBITMQ_URL=amqp://admin:admin@localhost:5672

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,0 +1,4 @@
+# Web application environment variables
+NODE_ENV=development
+PORT=3000
+NEXT_PUBLIC_API_URL=http://localhost:3001/api

--- a/apps/web/.gitignore
+++ b/apps/web/.gitignore
@@ -27,6 +27,7 @@ yarn-error.log*
 
 # env files (can opt-in for commiting if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel


### PR DESCRIPTION
## Summary
- add `.env.example` templates for the web app, API gateway, auth, tasks, and notifications services
- update root and web .gitignore rules to allow committing shared environment examples

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dff545b0b8832b933d320af5e37cfc