### PR TITLE
refactor: consolidate gateway entrypoint into api service

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -12,4 +12,4 @@ ENV NODE_ENV=development
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml turbo.json ./
 COPY packages ./packages
 COPY apps/api ./apps/api
-CMD ["pnpm", "--filter", "api-gateway...", "dev"]
+CMD ["pnpm", "--filter", "api...", "dev"]

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "api-gateway",
+  "name": "api",
   "version": "0.0.1",
   "description": "",
   "author": "",
@@ -78,6 +78,10 @@
     "testRegex": ".*\\.spec\\.ts$",
     "transform": {
       "^.+\\.(t|j)s$": "ts-jest"
+    },
+    "moduleNameMapper": {
+      "^@repo/contracts$": "<rootDir>/../test/__mocks__/repo-contracts.ts",
+      "^@repo/contracts/(.*)$": "<rootDir>/../test/__mocks__/repo-contracts/$1.ts"
     },
     "collectCoverageFrom": [
       "**/*.(t|j)s"

--- a/apps/api/src/health/health.service.ts
+++ b/apps/api/src/health/health.service.ts
@@ -28,7 +28,7 @@ export class HealthService {
       status: degraded ? 'degraded' : 'ok',
       ts: now,
       services: {
-        gateway: {
+        api: {
           status: 'ok' as const,
           latencyMs: 0,
           details: { ts: now },

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -19,16 +19,16 @@ async function bootstrap() {
 
   const origin = config.get<string>('CORS_ORIGIN', '*');
 
-  app.setGlobalPrefix('api');
-
   app.enableCors({
     origin: origin.split(','),
     methods: 'GET,HEAD,PUT,PATCH,POST,DELETE,OPTIONS',
     credentials: true,
   });
 
+  app.setGlobalPrefix('api');
+
   const docConfig = new DocumentBuilder()
-    .setTitle('Jungle Tasks — API Gateway')
+    .setTitle('Jungle Gaming — API')
     .setDescription('HTTP entrypoint for Jungle microservices')
     .setVersion('0.1.0')
     .addBearerAuth({ type: 'http', scheme: 'bearer', bearerFormat: 'JWT' })


### PR DESCRIPTION
## Summary
- remove the standalone gateway application and fold its HTTP configuration into the existing API service
- wire the API with the throttler guard, Swagger placeholder, and updated health reporting so the main entrypoint exposes rate limiting and docs
- refresh API tooling to reference the renamed workspace package and keep Jest unit tests working with contract mocks

## Testing
- pnpm --filter api test
- pnpm --filter api test:e2e

------
https://chatgpt.com/codex/tasks/task_e_68dff6bcd344832bb53b98f4ec8b8762