### PR TITLE
feat: add shared dto types package

### DIFF
--- a/packages/types/eslint.config.mjs
+++ b/packages/types/eslint.config.mjs
@@ -1,0 +1,3 @@
+import { config } from "@repo/eslint-config/base";
+
+export default config;

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@repo/types",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./*": {
+      "types": "./dist/*.d.ts",
+      "default": "./dist/*.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "lint": "eslint . --ext .ts --max-warnings 0",
+    "check-types": "tsc --noEmit",
+    "prepare": "pnpm run build"
+  },
+  "devDependencies": {
+    "@repo/eslint-config": "workspace:*",
+    "@repo/typescript-config": "workspace:*",
+    "@types/node": "^22.15.3",
+    "eslint": "^9.34.0",
+    "typescript": "5.9.2"
+  }
+}

--- a/packages/types/src/dtos/comment.ts
+++ b/packages/types/src/dtos/comment.ts
@@ -1,0 +1,8 @@
+export interface CommentDTO {
+  id: string;
+  taskId: string;
+  authorId: string;
+  message: string;
+  createdAt: string;
+  updatedAt: string;
+}

--- a/packages/types/src/dtos/index.ts
+++ b/packages/types/src/dtos/index.ts
@@ -1,0 +1,4 @@
+export * from "./user.js";
+export * from "./tokens.js";
+export * from "./task.js";
+export * from "./comment.js";

--- a/packages/types/src/dtos/task.ts
+++ b/packages/types/src/dtos/task.ts
@@ -1,0 +1,14 @@
+export type TaskStatus = "pending" | "in_progress" | "completed" | "archived";
+export type TaskPriority = "low" | "medium" | "high" | "critical";
+
+export interface TaskDTO {
+  id: string;
+  title: string;
+  description?: string | null;
+  status: TaskStatus;
+  priority: TaskPriority;
+  dueDate?: string | null;
+  assignedTo?: string | null;
+  createdAt: string;
+  updatedAt: string;
+}

--- a/packages/types/src/dtos/tokens.ts
+++ b/packages/types/src/dtos/tokens.ts
@@ -1,0 +1,6 @@
+export interface TokensDTO {
+  accessToken: string;
+  refreshToken: string;
+  expiresIn: number;
+  tokenType: "Bearer" | string;
+}

--- a/packages/types/src/dtos/user.ts
+++ b/packages/types/src/dtos/user.ts
@@ -1,0 +1,8 @@
+export interface UserDTO {
+  id: string;
+  username: string;
+  email: string;
+  avatarUrl?: string | null;
+  createdAt: string;
+  updatedAt: string;
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./dtos/index.js";

--- a/packages/types/tsconfig.json
+++ b/packages/types/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "@repo/typescript-config/base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "declaration": true,
+    "emitDeclarationOnly": false,
+    "rootDir": "src",
+    "composite": true,
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "resolvePackageJsonExports": true,
+    "incremental": true
+  },
+  "include": ["src/**/*.ts", "src/**/*.d.ts"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -599,6 +599,24 @@ importers:
         specifier: ^8.40.0
         version: 8.40.0(eslint@9.34.0)(typescript@5.9.2)
 
+  packages/types:
+    devDependencies:
+      '@repo/eslint-config':
+        specifier: workspace:*
+        version: link:../eslint-config
+      '@repo/typescript-config':
+        specifier: workspace:*
+        version: link:../typescript-config
+      '@types/node':
+        specifier: ^22.15.3
+        version: 22.15.3
+      eslint:
+        specifier: ^9.34.0
+        version: 9.34.0
+      typescript:
+        specifier: 5.9.2
+        version: 5.9.2
+
   packages/typescript-config: {}
 
   packages/ui:


### PR DESCRIPTION
## Summary
- add a new @repo/types workspace package for sharing DTO definitions
- define initial DTOs for users, tokens, tasks, and comments with consolidated exports
- configure TypeScript, ESLint, and workspace metadata for the new package

## Testing
- pnpm --filter @repo/types build
- pnpm --filter @repo/types lint
- pnpm --filter @repo/types check-types

------
https://chatgpt.com/codex/tasks/task_e_68dffe1205dc832bbe5267acff57e4d1