### PR TITLE
fix: enable tailwindcss plugin for web service

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -2,12 +2,14 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import { tanstackRouter } from '@tanstack/router-plugin/vite'
 import tsconfigPaths from 'vite-tsconfig-paths'
+import tailwindcss from '@tailwindcss/vite'
 import { fileURLToPath, URL } from 'node:url'
 
 export default defineConfig({
   plugins: [
     tanstackRouter({ target: 'react', autoCodeSplitting: true }),
     tsconfigPaths(),
+    tailwindcss(),
     react(),
   ],
   resolve: {


### PR DESCRIPTION
## Summary
- enable the Tailwind CSS Vite plugin in the web service so Tailwind directives in styles.css are processed

## Testing
- pnpm build *(fails: existing build error "default" is not exported by src/components/Header.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68e04cf847a8832ba1381187e8439708