### PR TITLE
feat: create login form with shadcn UI

### DIFF
--- a/apps/web/src/components/auth/login/form.tsx
+++ b/apps/web/src/components/auth/login/form.tsx
@@ -1,3 +1,111 @@
+import { zodResolver } from "@hookform/resolvers/zod"
+import { useForm } from "react-hook-form"
+import { z } from "zod"
+
+import { Button } from "@/components/ui/button"
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form"
+import { Input } from "@/components/ui/input"
+
+const loginSchema = z.object({
+  email: z
+    .string({ required_error: "Informe seu email" })
+    .min(1, "Informe seu email")
+    .email("Digite um email válido"),
+  password: z
+    .string({ required_error: "Digite sua senha" })
+    .min(8, "A senha precisa ter ao menos 8 caracteres"),
+})
+
+type LoginFormValues = z.infer<typeof loginSchema>
+
 export function LoginForm() {
-  return <div>Login Form</div>
+  const form = useForm<LoginFormValues>({
+    resolver: zodResolver(loginSchema),
+    mode: "onChange",
+    reValidateMode: "onChange",
+    defaultValues: {
+      email: "",
+      password: "",
+    },
+  })
+
+  const onSubmit = (values: LoginFormValues) => {
+    // Apenas exibe os valores por enquanto; integração com API virá depois.
+    console.log(values)
+  }
+
+  return (
+    <div className="w-full max-w-sm rounded-xl border border-border/60 bg-background/95 p-6 shadow-md backdrop-blur-sm">
+      <header className="mb-6 space-y-1 text-center">
+        <h1 className="text-2xl font-semibold tracking-tight">Bem-vindo de volta</h1>
+        <p className="text-sm text-muted-foreground">
+          Acesse sua conta informando email e senha cadastrados.
+        </p>
+      </header>
+
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-5">
+          <FormField
+            control={form.control}
+            name="email"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Email</FormLabel>
+                <FormControl>
+                  <Input
+                    type="email"
+                    placeholder="nome@email.com"
+                    autoComplete="email"
+                    {...field}
+                  />
+                </FormControl>
+                <FormDescription>
+                  Usamos seu email para confirmar sua identidade.
+                </FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="password"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Senha</FormLabel>
+                <FormControl>
+                  <Input
+                    type="password"
+                    placeholder="********"
+                    autoComplete="current-password"
+                    {...field}
+                  />
+                </FormControl>
+                <FormDescription>
+                  A senha deve ter no mínimo 8 caracteres.
+                </FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <Button
+            type="submit"
+            className="w-full"
+            disabled={!form.formState.isValid || form.formState.isSubmitting}
+          >
+            Entrar
+          </Button>
+        </form>
+      </Form>
+    </div>
+  )
 }

--- a/apps/web/src/components/ui/form.tsx
+++ b/apps/web/src/components/ui/form.tsx
@@ -1,0 +1,181 @@
+import * as React from "react"
+import { Slot } from "@radix-ui/react-slot"
+import { Controller, FormProvider, useFormContext } from "react-hook-form"
+import type {
+  ControllerProps,
+  FieldPath,
+  FieldValues,
+} from "react-hook-form"
+
+import { cn } from "@/lib/utils"
+import { Label } from "./label"
+
+const Form = FormProvider
+
+type FormFieldContextValue<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+> = {
+  name: TName
+}
+
+const FormFieldContext = React.createContext<FormFieldContextValue | undefined>(
+  undefined,
+)
+
+const FormItemContext = React.createContext<
+  | {
+      id: string
+      formItemId: string
+      formDescriptionId: string
+      formMessageId: string
+    }
+  | undefined
+>(undefined)
+
+const FormField = <TFieldValues extends FieldValues, TName extends FieldPath<TFieldValues>>({
+  ...props
+}: ControllerProps<TFieldValues, TName>) => {
+  return (
+    <FormFieldContext.Provider value={{ name: props.name }}>
+      <Controller {...props} />
+    </FormFieldContext.Provider>
+  )
+}
+
+const useFormField = () => {
+  const fieldContext = React.useContext(FormFieldContext)
+  const itemContext = React.useContext(FormItemContext)
+  const { getFieldState, formState } = useFormContext()
+
+  if (!fieldContext) {
+    throw new Error("useFormField should be used within <FormField>")
+  }
+
+  const fieldState = getFieldState(fieldContext.name, formState)
+
+  return {
+    id: itemContext?.id,
+    name: fieldContext.name,
+    formItemId: itemContext?.formItemId,
+    formDescriptionId: itemContext?.formDescriptionId,
+    formMessageId: itemContext?.formMessageId,
+    ...fieldState,
+  }
+}
+
+const FormItem = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => {
+  const id = React.useId()
+
+  return (
+    <FormItemContext.Provider
+      value={{
+        id,
+        formItemId: `${id}-form-item`,
+        formDescriptionId: `${id}-form-description`,
+        formMessageId: `${id}-form-message`,
+      }}
+    >
+      <div ref={ref} className={cn("space-y-2", className)} {...props} />
+    </FormItemContext.Provider>
+  )
+})
+FormItem.displayName = "FormItem"
+
+const FormLabel = React.forwardRef<
+  React.ElementRef<typeof Label>,
+  React.ComponentPropsWithoutRef<typeof Label>
+>(({ className, ...props }, ref) => {
+  const { error, formItemId } = useFormField()
+
+  return (
+    <Label
+      ref={ref}
+      className={cn(error && "text-destructive", className)}
+      htmlFor={formItemId}
+      {...props}
+    />
+  )
+})
+FormLabel.displayName = "FormLabel"
+
+const FormControl = React.forwardRef<
+  React.ElementRef<typeof Slot>,
+  React.ComponentPropsWithoutRef<typeof Slot>
+>(({ ...props }, ref) => {
+  const { error, formItemId, formDescriptionId, formMessageId } = useFormField()
+
+  const describedBy = [
+    formDescriptionId,
+    error ? formMessageId : undefined,
+  ]
+    .filter(Boolean)
+    .join(" ")
+
+  return (
+    <Slot
+      ref={ref}
+      id={formItemId}
+      aria-describedby={describedBy || undefined}
+      aria-invalid={!!error}
+      data-slot="form-control"
+      {...props}
+    />
+  )
+})
+FormControl.displayName = "FormControl"
+
+const FormDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => {
+  const { formDescriptionId } = React.useContext(FormItemContext) ?? {}
+
+  return (
+    <p
+      ref={ref}
+      id={formDescriptionId}
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+})
+FormDescription.displayName = "FormDescription"
+
+const FormMessage = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, children, ...props }, ref) => {
+  const { error, formMessageId } = useFormField()
+  const body = error ? String(error.message ?? children) : children
+
+  if (!body) {
+    return null
+  }
+
+  return (
+    <p
+      ref={ref}
+      id={formMessageId}
+      className={cn("text-sm font-medium text-destructive", className)}
+      {...props}
+    >
+      {body}
+    </p>
+  )
+})
+FormMessage.displayName = "FormMessage"
+
+export {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+  useFormField,
+}

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -3,7 +3,11 @@ import react from '@vitejs/plugin-react'
 import { tanstackRouter } from '@tanstack/router-plugin/vite'
 import tsconfigPaths from 'vite-tsconfig-paths'
 import tailwindcss from '@tailwindcss/vite'
+import { createRequire } from 'node:module'
 import { fileURLToPath, URL } from 'node:url'
+
+const require = createRequire(import.meta.url)
+const zodV4CorePath = require.resolve('zod/v4/core')
 
 export default defineConfig({
   plugins: [
@@ -15,6 +19,10 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': fileURLToPath(new URL('./src', import.meta.url)),
+      'zod/v4/core': zodV4CorePath,
     },
+  },
+  optimizeDeps: {
+    include: ['zod', 'zod/v4', 'zod/v4/core'],
   },
 })


### PR DESCRIPTION
## Summary
- implement the login screen using shadcn form components with realtime zod validation
- add reusable form primitives that bridge react-hook-form with the design system controls
- update the Vite config so the dev server resolves the new zod v4 entrypoints correctly

## Testing
- `pnpm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68e07e1321dc832b855b302c6445b901