### PR TITLE
Fix login service to call API endpoint

### DIFF
--- a/apps/web/src/features/auth/login.ts
+++ b/apps/web/src/features/auth/login.ts
@@ -1,7 +1,43 @@
-import type { AuthLoginRequest } from '@contracts';
-import { createLogger } from 'vite';
+import type { AuthLoginRequest, AuthLoginResponse } from '@contracts'
+import { env } from '@/env'
 
-export async function login(params: AuthLoginRequest) {
-    createLogger().info('Login params: ' + JSON.stringify(params));
-  return params;
+const API_BASE_URL = env.SERVER_URL?.replace(/\/$/, '') ?? ''
+
+export async function login(
+  params: AuthLoginRequest,
+): Promise<AuthLoginResponse> {
+  const response = await fetch(`${API_BASE_URL}/api/auth/login`, {
+    method: 'POST',
+    credentials: 'include',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(params),
+  })
+
+  if (!response.ok) {
+    throw new Error(await extractErrorMessage(response))
+  }
+
+  return (await response.json()) as AuthLoginResponse
+}
+
+async function extractErrorMessage(response: Response) {
+  try {
+    const data = (await response.json()) as
+      | { message?: string | string[] }
+      | undefined
+
+    if (Array.isArray(data?.message)) {
+      return data.message.join(', ')
+    }
+
+    if (typeof data?.message === 'string' && data.message.trim().length > 0) {
+      return data.message
+    }
+  } catch (error) {
+    console.error('Erro ao interpretar resposta de login', error)
+  }
+
+  return 'Não foi possível realizar login. Tente novamente mais tarde.'
 }


### PR DESCRIPTION
## Summary
- replace the placeholder login service with a real request to the API
- surface backend error messages and configure the base URL via environment variables

## Testing
- pnpm --filter @apps/web test *(fails: no test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68e09b6d2ef4832b9defe63e273f4c98