### PR TITLE
Fix login service env access

### DIFF
--- a/apps/web/src/env.ts
+++ b/apps/web/src/env.ts
@@ -14,6 +14,7 @@ export const env = createEnv({
 
   client: {
     VITE_APP_TITLE: z.string().min(1).optional(),
+    VITE_API_BASE_URL: z.string().url().optional(),
   },
 
   /**

--- a/apps/web/src/features/auth/login.ts
+++ b/apps/web/src/features/auth/login.ts
@@ -1,7 +1,46 @@
-import type { AuthLoginRequest } from '@contracts';
-import { createLogger } from 'vite';
+import type { AuthLoginRequest, AuthLoginResponse } from '@contracts'
+import { env } from '@/env'
 
-export async function login(params: AuthLoginRequest) {
-    createLogger().info('Login params: ' + JSON.stringify(params));
-  return params;
+const API_BASE_URL = env.VITE_API_BASE_URL?.replace(/\/$/, '') ?? ''
+const LOGIN_ENDPOINT = API_BASE_URL
+  ? `${API_BASE_URL}/api/auth/login`
+  : '/api/auth/login'
+
+export async function login(
+  params: AuthLoginRequest,
+): Promise<AuthLoginResponse> {
+  const response = await fetch(LOGIN_ENDPOINT, {
+    method: 'POST',
+    credentials: 'include',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(params),
+  })
+
+  if (!response.ok) {
+    throw new Error(await extractErrorMessage(response))
+  }
+
+  return (await response.json()) as AuthLoginResponse
+}
+
+async function extractErrorMessage(response: Response) {
+  try {
+    const data = (await response.json()) as
+      | { message?: string | string[] }
+      | undefined
+
+    if (Array.isArray(data?.message)) {
+      return data.message.join(', ')
+    }
+
+    if (typeof data?.message === 'string' && data.message.trim().length > 0) {
+      return data.message
+    }
+  } catch (error) {
+    console.error('Erro ao interpretar resposta de login', error)
+  }
+
+  return 'Não foi possível realizar login. Tente novamente mais tarde.'
 }


### PR DESCRIPTION
## Summary
- add a client-safe API base URL environment variable definition
- adjust the login service to use the client-exposed API base URL or fall back to a relative path

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e09b6d2ef4832b9defe63e273f4c98