### PR TITLE
feat: propagate auth error codes

### DIFF
--- a/apps/api/src/auth/auth-gateway.service.ts
+++ b/apps/api/src/auth/auth-gateway.service.ts
@@ -81,16 +81,30 @@ export class AuthGatewayService {
         'statusCode' in rpcError &&
         typeof (rpcError as { statusCode?: unknown }).statusCode === 'number'
       ) {
-        const { statusCode, message } = rpcError as {
+        const { statusCode, message, code } = rpcError as {
           statusCode: number;
           message?: unknown;
+          code?: unknown;
         };
         const normalizedMessage =
           typeof message === 'string'
             ? message
             : 'Internal server error';
+        const normalizedCode =
+          typeof code === 'string' ? code : undefined;
 
-        return new HttpException(normalizedMessage, statusCode);
+        const responseBody: Record<string, unknown> = {
+          statusCode,
+          message: normalizedMessage,
+        };
+
+        if (normalizedCode) {
+          responseBody.code = normalizedCode;
+        }
+
+        return new HttpException(responseBody, statusCode, {
+          cause: rpcError,
+        });
       }
 
       if (typeof rpcError === 'string') {

--- a/apps/api/src/common/filters/http-exception-code.filter.ts
+++ b/apps/api/src/common/filters/http-exception-code.filter.ts
@@ -1,0 +1,54 @@
+import { ArgumentsHost, Catch, ExceptionFilter, HttpException } from '@nestjs/common';
+import type { Response } from 'express';
+
+@Catch(HttpException)
+export class HttpExceptionCodeFilter implements ExceptionFilter {
+  catch(exception: HttpException, host: ArgumentsHost): void {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse<Response>();
+    const status = exception.getStatus();
+    const exceptionResponse = exception.getResponse();
+
+    const baseBody: Record<string, unknown> =
+      typeof exceptionResponse === 'string'
+        ? { message: exceptionResponse }
+        : { ...((exceptionResponse ?? {}) as Record<string, unknown>) };
+
+    const code = this.extractCode(baseBody, exception.cause);
+
+    const body: Record<string, unknown> = {
+      statusCode: status,
+      ...baseBody,
+    };
+
+    if (code) {
+      body.code = code;
+    }
+
+    if (typeof body.statusCode !== 'number') {
+      body.statusCode = status;
+    }
+
+    response.status(status).json(body);
+  }
+
+  private extractCode(
+    baseBody: Record<string, unknown>,
+    cause?: unknown,
+  ): string | undefined {
+    if (typeof baseBody.code === 'string') {
+      return baseBody.code;
+    }
+
+    if (
+      cause &&
+      typeof cause === 'object' &&
+      'code' in (cause as Record<string, unknown>) &&
+      typeof (cause as Record<string, unknown>).code === 'string'
+    ) {
+      return (cause as Record<string, string>).code;
+    }
+
+    return undefined;
+  }
+}

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -5,6 +5,7 @@ import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { AppModule } from './app.module';
 import cookieParser from 'cookie-parser';
 import helmet from 'helmet';
+import { HttpExceptionCodeFilter } from './common/filters/http-exception-code.filter';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
@@ -13,6 +14,7 @@ async function bootstrap() {
 
   app.use(cookieParser());
   app.use(helmet());
+  app.useGlobalFilters(new HttpExceptionCodeFilter());
 
   app.useGlobalPipes(
     new ValidationPipe({

--- a/apps/api/test/app.e2e-spec.ts
+++ b/apps/api/test/app.e2e-spec.ts
@@ -6,6 +6,10 @@ import { AppModule } from './../src/app.module';
 import { AUTH_SERVICE } from '../src/auth/auth.constants';
 import { RpcException } from '@nestjs/microservices';
 import { throwError } from 'rxjs';
+import {
+  AUTH_EMAIL_CONFLICT,
+  AUTH_INVALID_CREDENTIALS,
+} from '@contracts';
 
 describe('AppController (e2e)', () => {
   let app: INestApplication<App>;
@@ -42,6 +46,7 @@ describe('AppController (e2e)', () => {
           new RpcException({
             statusCode: HttpStatus.CONFLICT,
             message: 'Email address is already registered.',
+            code: AUTH_EMAIL_CONFLICT,
           }),
       ),
     );
@@ -54,8 +59,9 @@ describe('AppController (e2e)', () => {
         password: 'secret1',
       })
       .expect(HttpStatus.CONFLICT)
-      .expect(({ body }: { body: { message?: string } }) => {
+      .expect(({ body }: { body: { message?: string; code?: string } }) => {
         expect(body.message).toBe('Email address is already registered.');
+        expect(body.code).toBe(AUTH_EMAIL_CONFLICT);
       });
   });
 
@@ -66,6 +72,7 @@ describe('AppController (e2e)', () => {
           new RpcException({
             statusCode: HttpStatus.UNAUTHORIZED,
             message: 'Invalid username or password.',
+            code: AUTH_INVALID_CREDENTIALS,
           }),
       ),
     );
@@ -74,8 +81,9 @@ describe('AppController (e2e)', () => {
       .post('/auth/login')
       .send({ username: 'player@junglegaming.dev', password: 'secret1' })
       .expect(HttpStatus.UNAUTHORIZED)
-      .expect(({ body }: { body: { message?: string } }) => {
+      .expect(({ body }: { body: { message?: string; code?: string } }) => {
         expect(body.message).toBe('Invalid username or password.');
+        expect(body.code).toBe(AUTH_INVALID_CREDENTIALS);
       });
   });
 });

--- a/packages/contracts/src/auth/codes.ts
+++ b/packages/contracts/src/auth/codes.ts
@@ -1,11 +1,3 @@
-export const AUTH_MESSAGE_PATTERNS = {
-  REGISTER: 'auth.register',
-  LOGIN: 'auth.login',
-  REFRESH: 'auth.refresh',
-  LOGOUT: 'auth.logout',
-  PING: 'auth.ping',
-};
-
 export const AUTH_EMAIL_CONFLICT = 'AUTH_EMAIL_CONFLICT';
 export const AUTH_INVALID_CREDENTIALS = 'AUTH_INVALID_CREDENTIALS';
 export const AUTH_REFRESH_TOKEN_MISSING = 'AUTH_REFRESH_TOKEN_MISSING';
@@ -16,4 +8,7 @@ export const AUTH_ERROR_CODES = {
   INVALID_CREDENTIALS: AUTH_INVALID_CREDENTIALS,
   REFRESH_TOKEN_MISSING: AUTH_REFRESH_TOKEN_MISSING,
   REFRESH_TOKEN_INVALID: AUTH_REFRESH_TOKEN_INVALID,
-};
+} as const;
+
+export type AuthErrorCode =
+  (typeof AUTH_ERROR_CODES)[keyof typeof AUTH_ERROR_CODES];

--- a/packages/contracts/src/auth/index.ts
+++ b/packages/contracts/src/auth/index.ts
@@ -1,2 +1,3 @@
 export * from './messages.js';
 export * from './schemas.js';
+export * from './codes.js';


### PR DESCRIPTION
## Summary
- add shared authentication error code constants in the contracts package
- attach error codes to auth service RpcExceptions and expose them via a gateway filter
- update API e2e tests to cover the new error response format

## Testing
- pnpm --filter @apps/api-gateway test:e2e
- pnpm --filter @apps/auth-service test -- --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_e_68e12f189a10832ba11b6017af45f8f0