### PR TITLE
Align auth contract DTOs with database schema

### DIFF
--- a/apps/api/test/app.e2e-spec.ts
+++ b/apps/api/test/app.e2e-spec.ts
@@ -118,7 +118,7 @@ describe('AppController (e2e)', () => {
         () =>
           new RpcException({
             statusCode: HttpStatus.UNAUTHORIZED,
-            message: 'Invalid username or password.',
+            message: 'Invalid email or password.',
             code: AUTH_INVALID_CREDENTIALS,
           }),
       ),
@@ -126,10 +126,10 @@ describe('AppController (e2e)', () => {
 
     await request(app.getHttpServer())
       .post('/auth/login')
-      .send({ username: 'player@junglegaming.dev', password: 'secret1' })
+      .send({ email: 'player@junglegaming.dev', password: 'secret1' })
       .expect(HttpStatus.UNAUTHORIZED)
       .expect(({ body }: { body: { message?: string; code?: string } }) => {
-        expect(body.message).toBe('Invalid username or password.');
+        expect(body.message).toBe('Invalid email or password.');
         expect(body.code).toBe(AUTH_INVALID_CREDENTIALS);
       });
   });

--- a/docs/COMANDOS.md
+++ b/docs/COMANDOS.md
@@ -254,7 +254,7 @@ docker exec -it rabbitmq rabbitmq-plugins list
 
 ```bash
 # registrar
-curl -X POST http://localhost:3001/api/auth/register   -H "Content-Type: application/json"   -d '{"email":"user@test.com","username":"user","password":"secret"}'
+curl -X POST http://localhost:3001/api/auth/register   -H "Content-Type: application/json"   -d '{"email":"user@test.com","name":"User","password":"secret"}'
 
 # login
 curl -X POST http://localhost:3001/api/auth/login   -H "Content-Type: application/json"   -d '{"email":"user@test.com","password":"secret"}'

--- a/packages/contracts/src/common/dtos/tokens.ts
+++ b/packages/contracts/src/common/dtos/tokens.ts
@@ -1,6 +1,4 @@
 export interface TokensDTO {
   accessToken: string;
   refreshToken: string;
-  expiresIn: number;
-  tokenType: 'Bearer' | string;
 }

--- a/packages/contracts/src/common/dtos/user.ts
+++ b/packages/contracts/src/common/dtos/user.ts
@@ -1,8 +1,5 @@
 export interface UserDTO {
   id: string;
-  username: string;
   email: string;
-  avatarUrl?: string | null;
-  createdAt: string;
-  updatedAt: string;
+  name: string;
 }

--- a/packages/types/src/dtos/tokens.ts
+++ b/packages/types/src/dtos/tokens.ts
@@ -1,6 +1,4 @@
 export interface TokensDTO {
   accessToken: string;
   refreshToken: string;
-  expiresIn: number;
-  tokenType: "Bearer" | string;
 }

--- a/packages/types/src/dtos/user.ts
+++ b/packages/types/src/dtos/user.ts
@@ -1,8 +1,5 @@
 export interface UserDTO {
   id: string;
-  username: string;
   email: string;
-  avatarUrl?: string | null;
-  createdAt: string;
-  updatedAt: string;
+  name: string;
 }


### PR DESCRIPTION
## Summary
- update shared user and token DTOs to match the fields stored by the auth database
- adjust API gateway tests and command documentation to use email-based credentials

## Testing
- CI=1 pnpm -F @apps/api-gateway test

------
https://chatgpt.com/codex/tasks/task_e_68e144196794832b9d9f3fceec818423