### PR TITLE
feat(web): manage auth tokens with zustand

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -34,7 +34,8 @@
     "tailwind-merge": "^3.0.2",
     "tailwindcss": "^4.0.6",
     "tw-animate-css": "^1.3.6",
-    "zod": "^4.1.11"
+    "zod": "^4.1.11",
+    "zustand": "^5.0.3"
   },
   "devDependencies": {
     "@tanstack/router-plugin": "^1.132.33",

--- a/apps/web/src/features/auth/login.ts
+++ b/apps/web/src/features/auth/login.ts
@@ -1,5 +1,8 @@
-import type { AuthLoginRequest, AuthLoginResponse, UserDTO } from '@contracts'
-import { env } from '@/env'
+import type { AuthLoginRequest, AuthLoginResponse, UserDTO } from '@contracts';
+
+import { env } from '@/env';
+
+import { useAuthStore } from './store';
 
 
 const API_BASE_URL = env.VITE_API_BASE_URL?.replace(/\/$/, '') ?? ''
@@ -28,8 +31,17 @@ export async function login(
   }
 
   const data = await response.json() as AuthLoginResponse;
-  
-  console.log('Token:', data.accessToken);
+
+  const { setAuth } = useAuthStore.getState();
+
+  setAuth({
+    user: data.user,
+    tokens: {
+      accessToken: data.accessToken,
+      refreshToken: data.refreshToken,
+    },
+  });
+
   return data.user as UserDTO;
 
 }

--- a/apps/web/src/features/auth/store.ts
+++ b/apps/web/src/features/auth/store.ts
@@ -1,0 +1,61 @@
+import type { AuthTokens, AuthUser } from '@contracts'
+import { create } from 'zustand'
+import { createJSONStorage, persist } from 'zustand/middleware'
+import type { StateStorage } from 'zustand/middleware'
+
+interface AuthState {
+  user: AuthUser | null
+  tokens: AuthTokens | null
+  isAuthenticated: boolean
+  setAuth: (payload: { user: AuthUser; tokens: AuthTokens }) => void
+  clearAuth: () => void
+}
+
+const createStorage = (): StateStorage => {
+  if (typeof window === 'undefined') {
+    const memoryStorage: Record<string, string> = {}
+
+    return {
+      getItem: (name) => memoryStorage[name] ?? null,
+      setItem: (name, value) => {
+        memoryStorage[name] = value
+      },
+      removeItem: (name) => {
+        delete memoryStorage[name]
+      },
+    }
+  }
+
+  return window.localStorage
+}
+
+export const useAuthStore = create<AuthState>()(
+  persist(
+    (set) => ({
+      user: null,
+      tokens: null,
+      isAuthenticated: false,
+      setAuth: ({ user, tokens }) =>
+        set({
+          user,
+          tokens,
+          isAuthenticated: true,
+        }),
+      clearAuth: () =>
+        set({
+          user: null,
+          tokens: null,
+          isAuthenticated: false,
+        }),
+    }),
+    {
+      name: 'auth-storage',
+      storage: createJSONStorage(createStorage),
+      partialize: (state) => ({
+        user: state.user,
+        tokens: state.tokens,
+        isAuthenticated: state.isAuthenticated,
+      }),
+    },
+  ),
+)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -603,6 +603,9 @@ importers:
       zod:
         specifier: ^4.1.11
         version: 4.1.11
+      zustand:
+        specifier: ^5.0.3
+        version: 5.0.8(@types/react@19.1.0)(react@19.2.0)(use-sync-external-store@1.6.0(react@19.2.0))
     devDependencies:
       '@tanstack/router-plugin':
         specifier: ^1.132.33
@@ -6402,6 +6405,24 @@ packages:
 
   zod@4.1.11:
     resolution: {integrity: sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==}
+
+  zustand@5.0.8:
+    resolution: {integrity: sha512-gyPKpIaxY9XcO2vSMrLbiER7QMAMGOQZVRdJ6Zi782jkbzZygq5GI9nG8g+sMgitRtndwaBSl7uiqC49o1SSiw==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
 
 snapshots:
 
@@ -12543,3 +12564,9 @@ snapshots:
   zod@3.25.76: {}
 
   zod@4.1.11: {}
+
+  zustand@5.0.8(@types/react@19.1.0)(react@19.2.0)(use-sync-external-store@1.6.0(react@19.2.0)):
+    optionalDependencies:
+      '@types/react': 19.1.0
+      react: 19.2.0
+      use-sync-external-store: 1.6.0(react@19.2.0)


### PR DESCRIPTION
## Summary
- add zustand as a dependency in the web app
- create a persisted auth store to keep user and token data
- update the login service to populate the store after a successful authentication

## Testing
- pnpm --filter @apps/web test *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68e1bb52ea94832b85458b92a7be6291