### PR TITLE
fix(login): update login schema validation

### DIFF
--- a/apps/web/src/components/auth/login/form.tsx
+++ b/apps/web/src/components/auth/login/form.tsx
@@ -1,6 +1,6 @@
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useForm } from "react-hook-form"
-import { set, z } from "zod"
+import { z } from "zod"
 
 import { Button } from "@/components/ui/button"
 import {
@@ -16,7 +16,6 @@ import { Input } from "@/components/ui/input"
 import { loginSchema } from "../../../schemas/loginSchema"
 import { login } from "@/features/auth/login"
 import { useState } from "react"
-
 
 
 type LoginFormValues = z.infer<typeof loginSchema>

--- a/apps/web/src/schemas/loginSchema.ts
+++ b/apps/web/src/schemas/loginSchema.ts
@@ -1,8 +1,9 @@
-import z from "zod";
+import z from "zod"
 
 export const loginSchema = z.object({
-    email: z.email("Digite um email válido")
-        .min(1, "Informe seu email"),
-    password: z
-        .string({ error: "Digite sua senha" })
+  email: z
+    .string()
+    .email("Digite um email válido")
+    .min(1, "Informe seu email"),
+  password: z.string({ required_error: "Digite sua senha" }),
 })


### PR DESCRIPTION
## Summary
- adjust login schema to validate email using string().email() and set required error for password
- clean up LoginForm imports to continue using the updated schema with zodResolver

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2874214a4832bab834aec13d4f5af