### PR TITLE
Remove sensitive login logging

### DIFF
--- a/apps/web/src/components/auth/login/form.tsx
+++ b/apps/web/src/components/auth/login/form.tsx
@@ -36,7 +36,6 @@ export function LoginForm() {
   const onSubmit = async (values: LoginFormValues) => {
     setLoginError('')
     const response = await login({ email: values.email, password: values.password });
-    console.log('Login response:', response);
     if (typeof response == 'string') {
       setLoginError(typeof response === 'string' ? response : '');
     }

--- a/apps/web/src/features/auth/login.ts
+++ b/apps/web/src/features/auth/login.ts
@@ -14,8 +14,6 @@ export async function login(
   params: AuthLoginRequest,
 ): Promise<UserDTO|string> {
 
-  console.log('Login params:', params);
-
   const response = await fetch(LOGIN_ENDPOINT, {
     method: 'POST',
     credentials: 'include',
@@ -56,7 +54,6 @@ async function extractErrorMessage(response: Response) {
       | undefined)
 
     if (Array.isArray(data?.message)) {
-      console.error('Erro de validação:', data.message)
       return (data.message as string[]).join(', ')
     }
 


### PR DESCRIPTION
## Summary
- remove console logging of raw login parameters and responses
- keep login error handling unchanged while avoiding exposure of sensitive data

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e2880e93f4832b9283827a5e6e4a8b