### PR TITLE
Refactor auth session handling to rely on refresh cookies

### DIFF
--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -13,7 +13,11 @@ import type { Request, Response } from 'express';
 import { AuthGatewayService } from './auth-gateway.service';
 import { buildRefreshCookieOptions } from './cookie.options';
 import { LoginDto, RegisterDto } from './dto';
-import type { AuthLoginResponse, AuthRegisterResponse } from '@contracts';
+import type {
+  AuthLoginResponse,
+  AuthRegisterResponse,
+  AuthSessionResponse,
+} from '@contracts';
 
 @ApiTags('auth')
 @Controller('auth')
@@ -26,7 +30,7 @@ export class AuthController {
   async register(
     @Body() dto: RegisterDto,
     @Res({ passthrough: true }) res: Response,
-  ): Promise<Omit<AuthRegisterResponse, 'refreshToken'>> {
+  ): Promise<AuthSessionResponse> {
     const { user, accessToken, refreshToken } =
       await this.authService.register(dto);
 
@@ -42,7 +46,7 @@ export class AuthController {
   async login(
     @Body() dto: LoginDto,
     @Res({ passthrough: true }) res: Response,
-  ): Promise<Omit<AuthLoginResponse, 'refreshToken'>> {
+  ): Promise<AuthSessionResponse> {
     const { user, accessToken, refreshToken } =
       await this.authService.login(dto);
 

--- a/apps/web/src/features/auth/login.ts
+++ b/apps/web/src/features/auth/login.ts
@@ -1,4 +1,8 @@
-import type { AuthLoginRequest, AuthLoginResponse, UserDTO } from '@contracts';
+import type {
+  AuthLoginRequest,
+  AuthSessionResponse,
+  UserDTO,
+} from '@contracts';
 
 import { env } from '@/env';
 
@@ -28,17 +32,11 @@ export async function login(
     return extractErrorMessage(response);
   }
 
-  const data = await response.json() as AuthLoginResponse;
+  const data = await response.json() as AuthSessionResponse;
 
   const { setAuth } = useAuthStore.getState();
 
-  setAuth({
-    user: data.user,
-    tokens: {
-      accessToken: data.accessToken,
-      refreshToken: data.refreshToken,
-    },
-  });
+  setAuth(data);
 
   return data.user as UserDTO;
 

--- a/apps/web/src/features/auth/store.ts
+++ b/apps/web/src/features/auth/store.ts
@@ -1,13 +1,13 @@
-import type { AuthTokens, AuthUser } from '@contracts'
+import type { AuthSession, AuthUser } from '@contracts'
 import { create } from 'zustand'
 import { createJSONStorage, persist } from 'zustand/middleware'
 import type { StateStorage } from 'zustand/middleware'
 
 interface AuthState {
   user: AuthUser | null
-  tokens: AuthTokens | null
+  session: AuthSession | null
   isAuthenticated: boolean
-  setAuth: (payload: { user: AuthUser; tokens: AuthTokens }) => void
+  setAuth: (session: AuthSession) => void
   clearAuth: () => void
 }
 
@@ -33,18 +33,18 @@ export const useAuthStore = create<AuthState>()(
   persist(
     (set) => ({
       user: null,
-      tokens: null,
+      session: null,
       isAuthenticated: false,
-      setAuth: ({ user, tokens }) =>
+      setAuth: (session) =>
         set({
-          user,
-          tokens,
+          user: session.user,
+          session,
           isAuthenticated: true,
         }),
       clearAuth: () =>
         set({
           user: null,
-          tokens: null,
+          session: null,
           isAuthenticated: false,
         }),
     }),
@@ -53,7 +53,7 @@ export const useAuthStore = create<AuthState>()(
       storage: createJSONStorage(createStorage),
       partialize: (state) => ({
         user: state.user,
-        tokens: state.tokens,
+        session: state.session,
         isAuthenticated: state.isAuthenticated,
       }),
     },

--- a/packages/contracts/src/auth/schemas.ts
+++ b/packages/contracts/src/auth/schemas.ts
@@ -9,6 +9,13 @@ export interface AuthTokens {
   refreshToken: string;
 }
 
+export interface AuthSession {
+  user: AuthUser;
+  accessToken: string;
+}
+
+export type AuthSessionResponse = AuthSession;
+
 export interface AuthRegisterRequest {
   email: string;
   name: string;


### PR DESCRIPTION
## Summary
- add an AuthSession contract to share `{ user, accessToken }` between services and clients
- update the API auth controller and web login flow to return and consume the new session response without exposing refresh tokens
- refactor the web auth store to persist only the authenticated session and rely on cookie-based refresh

## Testing
- pnpm --filter @contracts build

------
https://chatgpt.com/codex/tasks/task_e_68e28936d8d0832b9bab903fdc9b2200