### PR TITLE
feat(contracts): update task DTOs

### DIFF
--- a/packages/contracts/src/common/dtos/task.ts
+++ b/packages/contracts/src/common/dtos/task.ts
@@ -1,17 +1,38 @@
-export const TASK_PRIORITIES = ['low', 'medium', 'high', 'critical'] as const;
-export type TaskPriority = (typeof TASK_PRIORITIES)[number];
+export enum TaskStatus {
+  TODO = 'TODO',
+  IN_PROGRESS = 'IN_PROGRESS',
+  REVIEW = 'REVIEW',
+  DONE = 'DONE',
+}
 
-export const TASK_STATUSES = ['pending', 'in_progress', 'completed', 'archived'] as const;
-export type TaskStatus = (typeof TASK_STATUSES)[number];
+export enum TaskPriority {
+  LOW = 'LOW',
+  MEDIUM = 'MEDIUM',
+  HIGH = 'HIGH',
+  URGENT = 'URGENT',
+}
 
-export interface TaskDTO {
+export interface Task {
   id: string;
   title: string;
   description?: string | null;
   status: TaskStatus;
   priority: TaskPriority;
   dueDate?: string | null;
-  assignedTo?: string | null;
+  assignees: { id: string; username: string }[];
   createdAt: string;
   updatedAt: string;
 }
+
+export interface CreateTask {
+  title: string;
+  description?: string | null;
+  status: TaskStatus;
+  priority: TaskPriority;
+  dueDate?: string | null;
+  assignees: { id: string; username: string }[];
+}
+
+export type UpdateTask = Partial<CreateTask> & {
+  status?: TaskStatus;
+};


### PR DESCRIPTION
## Summary
- replace task status and priority constants with enums and extend the task DTO structure
- introduce CreateTask and UpdateTask DTOs for task creation and updates

## Testing
- pnpm --filter @contracts build

------
https://chatgpt.com/codex/tasks/task_e_68e2ae56d4ec832bbd526ea260f9627b