### PR TITLE
feat(tasks): add service/controller and task events

### DIFF
--- a/apps/tasks/src/tasks/tasks.constants.ts
+++ b/apps/tasks/src/tasks/tasks.constants.ts
@@ -1,0 +1,2 @@
+export const TASKS_EVENTS_CLIENT = 'TASKS_EVENTS_CLIENT';
+export const TASKS_EVENTS_QUEUE = 'tasks.events';

--- a/apps/tasks/src/tasks/tasks.controller.ts
+++ b/apps/tasks/src/tasks/tasks.controller.ts
@@ -1,0 +1,130 @@
+import {
+  BadRequestException,
+  Controller,
+  HttpException,
+} from '@nestjs/common';
+import { MessagePattern, Payload, RpcException } from '@nestjs/microservices';
+import { plainToInstance, Type } from 'class-transformer';
+import {
+  IsNotEmpty,
+  IsNotEmptyObject,
+  IsUUID,
+  ValidateNested,
+  validateSync,
+} from 'class-validator';
+import { TasksService } from './tasks.service';
+import { CreateTaskDto } from './create-task.dto';
+import { ListTasksDto } from './list-tasks.dto';
+import { UpdateTaskDto } from './update-task.dto';
+
+class TaskIdDto {
+  @IsUUID()
+  @IsNotEmpty()
+  id: string;
+}
+
+class UpdateTaskPayloadDto {
+  @IsUUID()
+  @IsNotEmpty()
+  id: string;
+
+  @ValidateNested()
+  @IsNotEmptyObject({ nullable: false })
+  @Type(() => UpdateTaskDto)
+  data: UpdateTaskDto;
+}
+
+@Controller()
+export class TasksController {
+  constructor(private readonly tasksService: TasksService) {}
+
+  @MessagePattern('tasks.create')
+  async create(@Payload() payload: unknown) {
+    try {
+      const dto = this.transformPayload(CreateTaskDto, payload);
+      return await this.tasksService.create(dto);
+    } catch (error) {
+      throw this.toRpcException(error);
+    }
+  }
+
+  @MessagePattern('tasks.findAll')
+  async findAll(@Payload() payload: unknown) {
+    try {
+      const dto = this.transformPayload(ListTasksDto, payload ?? {});
+      return await this.tasksService.findAll(dto);
+    } catch (error) {
+      throw this.toRpcException(error);
+    }
+  }
+
+  @MessagePattern('tasks.findById')
+  async findById(@Payload() payload: unknown) {
+    try {
+      const { id } = this.transformPayload(TaskIdDto, payload);
+      return await this.tasksService.findById(id);
+    } catch (error) {
+      throw this.toRpcException(error);
+    }
+  }
+
+  @MessagePattern('tasks.update')
+  async update(@Payload() payload: unknown) {
+    try {
+      const { id, data } = this.transformPayload(UpdateTaskPayloadDto, payload);
+      return await this.tasksService.update(id, data);
+    } catch (error) {
+      throw this.toRpcException(error);
+    }
+  }
+
+  @MessagePattern('tasks.remove')
+  async remove(@Payload() payload: unknown) {
+    try {
+      const { id } = this.transformPayload(TaskIdDto, payload);
+      return await this.tasksService.remove(id);
+    } catch (error) {
+      throw this.toRpcException(error);
+    }
+  }
+
+  private transformPayload<T>(cls: new () => T, payload: unknown): T {
+    const dto = plainToInstance(cls, payload, {
+      enableImplicitConversion: true,
+      exposeDefaultValues: true,
+    });
+
+    const errors = validateSync(dto as object, {
+      whitelist: true,
+      forbidUnknownValues: true,
+      forbidNonWhitelisted: true,
+    });
+
+    if (errors.length > 0) {
+      throw new BadRequestException(errors);
+    }
+
+    return dto;
+  }
+
+  private toRpcException(error: unknown): RpcException {
+    if (error instanceof RpcException) {
+      return error;
+    }
+
+    if (error instanceof HttpException) {
+      return new RpcException({
+        status: error.getStatus(),
+        response: error.getResponse(),
+      });
+    }
+
+    if (error instanceof Error) {
+      return new RpcException({
+        message: error.message,
+      });
+    }
+
+    return new RpcException(error as Record<string, unknown>);
+  }
+}

--- a/apps/tasks/src/tasks/tasks.module.ts
+++ b/apps/tasks/src/tasks/tasks.module.ts
@@ -1,9 +1,41 @@
 import { Module } from '@nestjs/common';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { ClientsModule, Transport } from '@nestjs/microservices';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Task } from './task.entity';
+import { TasksService } from './tasks.service';
+import { TasksController } from './tasks.controller';
+import { TASKS_EVENTS_CLIENT, TASKS_EVENTS_QUEUE } from './tasks.constants';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Task])],
-  exports: [TypeOrmModule],
+  imports: [
+    TypeOrmModule.forFeature([Task]),
+    ConfigModule,
+    ClientsModule.registerAsync([
+      {
+        name: TASKS_EVENTS_CLIENT,
+        imports: [ConfigModule],
+        inject: [ConfigService],
+        useFactory: (config: ConfigService) => ({
+          transport: Transport.RMQ,
+          options: {
+            urls: [
+              config.get<string>(
+                'RABBITMQ_URL',
+                'amqp://admin:admin@localhost:5672',
+              ),
+            ],
+            queue: TASKS_EVENTS_QUEUE,
+            queueOptions: {
+              durable: true,
+            },
+          },
+        }),
+      },
+    ]),
+  ],
+  controllers: [TasksController],
+  providers: [TasksService],
+  exports: [TypeOrmModule, TasksService],
 })
 export class TasksModule {}

--- a/apps/tasks/src/tasks/tasks.service.ts
+++ b/apps/tasks/src/tasks/tasks.service.ts
@@ -1,0 +1,130 @@
+import { Inject, Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { ClientProxy } from '@nestjs/microservices';
+import { defaultIfEmpty, lastValueFrom } from 'rxjs';
+import { Repository } from 'typeorm';
+import { Task } from './task.entity';
+import { CreateTaskDto } from './create-task.dto';
+import { ListTasksDto } from './list-tasks.dto';
+import { UpdateTaskDto } from './update-task.dto';
+import { TASKS_EVENTS_CLIENT } from './tasks.constants';
+
+interface PaginatedTasks {
+  data: Task[];
+  total: number;
+  page: number;
+  limit: number;
+}
+
+@Injectable()
+export class TasksService {
+  constructor(
+    @InjectRepository(Task)
+    private readonly tasksRepository: Repository<Task>,
+    @Inject(TASKS_EVENTS_CLIENT)
+    private readonly eventsClient: ClientProxy,
+  ) {}
+
+  async create(dto: CreateTaskDto): Promise<Task> {
+    const task = this.tasksRepository.create({
+      ...dto,
+      dueDate: dto.dueDate ? new Date(dto.dueDate) : null,
+    });
+
+    const saved = await this.tasksRepository.save(task);
+    await this.emitEvent('task.created', saved);
+
+    return saved;
+  }
+
+  async findAll(filters: ListTasksDto): Promise<PaginatedTasks> {
+    const page = filters.page && filters.page > 0 ? filters.page : 1;
+    const limit = filters.limit && filters.limit > 0 ? filters.limit : 10;
+
+    const query = this.tasksRepository.createQueryBuilder('task');
+
+    if (filters.status) {
+      query.andWhere('task.status = :status', { status: filters.status });
+    }
+
+    if (filters.priority) {
+      query.andWhere('task.priority = :priority', { priority: filters.priority });
+    }
+
+    if (filters.search) {
+      query.andWhere(
+        '(task.title ILIKE :search OR task.description ILIKE :search)',
+        { search: `%${filters.search}%` },
+      );
+    }
+
+    if (filters.assigneeId) {
+      query.andWhere('task.assignees::jsonb @> :assignee', {
+        assignee: JSON.stringify([{ id: filters.assigneeId }]),
+      });
+    }
+
+    query.orderBy('task.createdAt', 'DESC');
+
+    const [data, total] = await query
+      .take(limit)
+      .skip((page - 1) * limit)
+      .getManyAndCount();
+
+    return {
+      data,
+      total,
+      page,
+      limit,
+    };
+  }
+
+  async findById(id: string): Promise<Task> {
+    const task = await this.tasksRepository.findOne({ where: { id } });
+
+    if (!task) {
+      throw new NotFoundException('Task not found');
+    }
+
+    return task;
+  }
+
+  async update(id: string, dto: UpdateTaskDto): Promise<Task> {
+    const task = await this.findById(id);
+
+    const updatePayload: Partial<Task> = {
+      ...dto,
+    };
+
+    if (dto.dueDate !== undefined) {
+      updatePayload.dueDate = dto.dueDate ? new Date(dto.dueDate) : null;
+    }
+
+    this.tasksRepository.merge(task, updatePayload);
+
+    const saved = await this.tasksRepository.save(task);
+
+    await this.emitEvent('task.updated', saved);
+
+    return saved;
+  }
+
+  async remove(id: string): Promise<Task> {
+    const task = await this.findById(id);
+    const removed = await this.tasksRepository.remove(task);
+
+    await this.emitEvent('task.deleted', removed);
+
+    return removed;
+  }
+
+  private async emitEvent(pattern: string, payload: unknown): Promise<void> {
+    try {
+      await lastValueFrom(
+        this.eventsClient.emit(pattern, payload).pipe(defaultIfEmpty(undefined)),
+      );
+    } catch (error) {
+      // Intentionally swallow errors to avoid breaking the main workflow
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- implement a task service that delegates to TypeORM with CRUD operations, filtering, and RMQ event emissions
- expose message-pattern controller endpoints that validate DTO payloads and surface errors as RPC exceptions
- register an RMQ producer client in the tasks module for publishing task lifecycle events

## Testing
- pnpm lint --filter @apps/tasks-service *(fails: existing lint warning in packages/contracts)*

------
https://chatgpt.com/codex/tasks/task_e_68e2b23bf96c832ba1466693ad978c80