### PR TITLE
refactor: run tasks service as rmq microservice

### DIFF
--- a/apps/tasks/src/main.ts
+++ b/apps/tasks/src/main.ts
@@ -1,49 +1,43 @@
-import { NestFactory } from '@nestjs/core';
-import { AppModule } from './app.module';
-import { MicroserviceOptions, Transport } from '@nestjs/microservices';
-import { ConfigService } from '@nestjs/config';
-import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { NestFactory } from '@nestjs/core';
+import { MicroserviceOptions, Transport } from '@nestjs/microservices';
+
+import { AppModule } from './app.module';
 
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule);
+  const logger = new Logger('TasksBootstrap');
+  const configService = new ConfigService();
 
-  const config = app.get(ConfigService);
+  const rabbitMqUrl = configService.get<string>(
+    'RABBITMQ_URL',
+    'amqp://admin:admin@localhost:5672',
+  );
+  const queue = configService.get<string>('RABBITMQ_QUEUE', 'tasks.rpc');
+  const prefetchRaw = configService.get<string>('RABBITMQ_PREFETCH', '10');
+  const prefetch = Number.isNaN(Number(prefetchRaw))
+    ? 10
+    : Number(prefetchRaw);
 
-  const origin = config.get<string>('CORS_ORIGIN', '*');
-
-  app.enableCors({
-    origin: origin.split(','),
-    methods: 'GET,HEAD,PUT,PATCH,POST,DELETE,OPTIONS',
-    credentials: true,
-  });
-
-  // Swagger placeholder
-  const docConfig = new DocumentBuilder()
-    .setTitle('Jungle Tasks — API Gateway')
-    .setDescription('Placeholder da documentação HTTP via Swagger')
-    .setVersion('0.1.0')
-    .addBearerAuth({ type: 'http', scheme: 'bearer', bearerFormat: 'JWT' })
-    .build();
-
-  const document = SwaggerModule.createDocument(app, docConfig);
-  SwaggerModule.setup('/api/docs', app, document);
-
-  app.connectMicroservice<MicroserviceOptions>({
-    transport: Transport.RMQ,
-    options: {
-      urls: [process.env.RABBITMQ_URL ?? 'amqp://admin:admin@localhost:5672'],
-      queue: 'tasks.rpc',
-      queueOptions: {
-        durable: true,
-        prefetchCount: 10,
+  const app = await NestFactory.createMicroservice<MicroserviceOptions>(
+    AppModule,
+    {
+      transport: Transport.RMQ,
+      options: {
+        urls: [rabbitMqUrl],
+        queue,
+        queueOptions: {
+          durable: true,
+        },
+        prefetchCount: prefetch,
       },
     },
-  });
-  await app.startAllMicroservices();
-  await app.listen(process.env.PORT ?? 3003);
-  Logger.log(
-    `API docs available at http://localhost:${process.env.PORT ?? 3003}/api/docs`,
+  );
+
+  await app.listen();
+  logger.log(
+    `Tasks microservice connected to ${rabbitMqUrl} on queue "${queue}" (prefetch ${prefetch})`,
   );
 }
+
 void bootstrap();


### PR DESCRIPTION
## Summary
- bootstrap the tasks service directly as an RMQ microservice using ConfigService-provided connection details
- remove HTTP-specific setup and log the microservice connection on startup

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2b48ce8b0832b8e650d525292f093