### PR TITLE
feat: add task filters and view switcher components

### DIFF
--- a/apps/web/src/features/tasks/components/TaskFilters.tsx
+++ b/apps/web/src/features/tasks/components/TaskFilters.tsx
@@ -1,0 +1,148 @@
+import { type ChangeEvent } from 'react'
+import { TaskPriority, TaskStatus } from '@contracts'
+
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { cn } from '@/lib/utils'
+
+import {
+  type PriorityFilter,
+  type StatusFilter,
+  useTasksFilters,
+} from '../store/useTasksFilters'
+import { useTaskCreationModal } from '../store/useTaskCreationModal'
+
+const statusLabels: Record<Exclude<StatusFilter, 'ALL'>, string> = {
+  [TaskStatus.TODO]: 'A fazer',
+  [TaskStatus.IN_PROGRESS]: 'Em andamento',
+  [TaskStatus.REVIEW]: 'Em revisão',
+  [TaskStatus.DONE]: 'Concluída',
+}
+
+const priorityLabels: Record<Exclude<PriorityFilter, 'ALL'>, string> = {
+  [TaskPriority.LOW]: 'Baixa',
+  [TaskPriority.MEDIUM]: 'Média',
+  [TaskPriority.HIGH]: 'Alta',
+  [TaskPriority.URGENT]: 'Urgente',
+}
+
+const statusOptions: Array<{ value: StatusFilter; label: string }> = [
+  { value: 'ALL', label: 'Todos os status' },
+  { value: TaskStatus.TODO, label: statusLabels[TaskStatus.TODO] },
+  { value: TaskStatus.IN_PROGRESS, label: statusLabels[TaskStatus.IN_PROGRESS] },
+  { value: TaskStatus.REVIEW, label: statusLabels[TaskStatus.REVIEW] },
+  { value: TaskStatus.DONE, label: statusLabels[TaskStatus.DONE] },
+]
+
+const priorityOptions: Array<{ value: PriorityFilter; label: string }> = [
+  { value: 'ALL', label: 'Todas as prioridades' },
+  { value: TaskPriority.LOW, label: priorityLabels[TaskPriority.LOW] },
+  { value: TaskPriority.MEDIUM, label: priorityLabels[TaskPriority.MEDIUM] },
+  { value: TaskPriority.HIGH, label: priorityLabels[TaskPriority.HIGH] },
+  { value: TaskPriority.URGENT, label: priorityLabels[TaskPriority.URGENT] },
+]
+
+interface TaskFiltersProps {
+  className?: string
+  onCreateTask?: () => void
+}
+
+export function TaskFilters({ className, onCreateTask }: TaskFiltersProps) {
+  const { status, setStatus, priority, setPriority, dueDate, setDueDate } =
+    useTasksFilters()
+  const { open } = useTaskCreationModal()
+
+  const handleStatusChange = (value: string) => {
+    setStatus(value as StatusFilter)
+  }
+
+  const handlePriorityChange = (value: string) => {
+    setPriority(value as PriorityFilter)
+  }
+
+  const handleDueDateChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const value = event.target.value.trim()
+    setDueDate(value ? value : null)
+  }
+
+  const handleCreateTaskClick = () => {
+    if (onCreateTask) {
+      onCreateTask()
+      return
+    }
+
+    open()
+  }
+
+  return (
+    <div
+      className={cn(
+        'flex flex-wrap items-end justify-between gap-4 rounded-lg border border-border bg-card/40 p-4',
+        className,
+      )}
+    >
+      <div className="flex flex-wrap items-end gap-4">
+        <div className="flex min-w-[180px] flex-col gap-2">
+          <Label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            Status
+          </Label>
+          <Select value={status} onValueChange={handleStatusChange}>
+            <SelectTrigger size="sm" className="w-full">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {statusOptions.map((option) => (
+                <SelectItem key={option.value} value={option.value}>
+                  {option.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="flex min-w-[200px] flex-col gap-2">
+          <Label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            Prioridade
+          </Label>
+          <Select value={priority} onValueChange={handlePriorityChange}>
+            <SelectTrigger size="sm" className="w-full">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {priorityOptions.map((option) => (
+                <SelectItem key={option.value} value={option.value}>
+                  {option.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="flex min-w-[180px] flex-col gap-2">
+          <Label htmlFor="task-filter-due-date" className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            Prazo
+          </Label>
+          <Input
+            id="task-filter-due-date"
+            type="date"
+            value={dueDate ?? ''}
+            onChange={handleDueDateChange}
+            className="h-9"
+          />
+        </div>
+      </div>
+
+      <Button type="button" size="sm" onClick={handleCreateTaskClick}>
+        + Nova Tarefa
+      </Button>
+    </div>
+  )
+}

--- a/apps/web/src/features/tasks/components/ViewSwitcher.tsx
+++ b/apps/web/src/features/tasks/components/ViewSwitcher.tsx
@@ -1,0 +1,51 @@
+import { type LucideIcon, LayoutDashboard, List } from 'lucide-react'
+
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { cn } from '@/lib/utils'
+
+import {
+  type TasksViewMode,
+  useTasksView,
+} from '../store/useTasksView'
+
+const viewOptions: Array<{
+  value: TasksViewMode
+  label: string
+  icon: LucideIcon
+}> = [
+  { value: 'list', label: 'Lista', icon: List },
+  { value: 'board', label: 'Quadro', icon: LayoutDashboard },
+]
+
+interface ViewSwitcherProps {
+  className?: string
+}
+
+export function ViewSwitcher({ className }: ViewSwitcherProps) {
+  const { viewMode, setViewMode } = useTasksView()
+
+  const handleChange = (value: string) => {
+    setViewMode(value as TasksViewMode)
+  }
+
+  return (
+    <Tabs
+      value={viewMode}
+      onValueChange={handleChange}
+      className={cn('w-fit', className)}
+    >
+      <TabsList>
+        {viewOptions.map((option) => {
+          const Icon = option.icon
+
+          return (
+            <TabsTrigger key={option.value} value={option.value}>
+              <Icon className="size-4" />
+              <span>{option.label}</span>
+            </TabsTrigger>
+          )
+        })}
+      </TabsList>
+    </Tabs>
+  )
+}

--- a/apps/web/src/features/tasks/store/useTaskCreationModal.ts
+++ b/apps/web/src/features/tasks/store/useTaskCreationModal.ts
@@ -1,0 +1,13 @@
+import { create } from 'zustand'
+
+interface TaskCreationModalState {
+  isOpen: boolean
+  open: () => void
+  close: () => void
+}
+
+export const useTaskCreationModal = create<TaskCreationModalState>((set) => ({
+  isOpen: false,
+  open: () => set({ isOpen: true }),
+  close: () => set({ isOpen: false }),
+}))

--- a/apps/web/src/features/tasks/store/useTasksFilters.ts
+++ b/apps/web/src/features/tasks/store/useTasksFilters.ts
@@ -3,21 +3,28 @@ import { create } from 'zustand'
 
 type StatusFilter = 'ALL' | TaskStatus
 type PriorityFilter = 'ALL' | TaskPriority
+type DueDateFilter = string | null
 
 interface TasksFiltersState {
   searchTerm: string
   status: StatusFilter
   priority: PriorityFilter
+  dueDate: DueDateFilter
   setSearchTerm: (searchTerm: string) => void
   setStatus: (status: StatusFilter) => void
   setPriority: (priority: PriorityFilter) => void
+  setDueDate: (dueDate: DueDateFilter) => void
   resetFilters: () => void
 }
 
-const initialState: Pick<TasksFiltersState, 'searchTerm' | 'status' | 'priority'> = {
+const initialState: Pick<
+  TasksFiltersState,
+  'searchTerm' | 'status' | 'priority' | 'dueDate'
+> = {
   searchTerm: '',
   status: 'ALL',
   priority: 'ALL',
+  dueDate: null,
 }
 
 export const useTasksFilters = create<TasksFiltersState>((set) => ({
@@ -25,7 +32,8 @@ export const useTasksFilters = create<TasksFiltersState>((set) => ({
   setSearchTerm: (searchTerm) => set({ searchTerm }),
   setStatus: (status) => set({ status }),
   setPriority: (priority) => set({ priority }),
+  setDueDate: (dueDate) => set({ dueDate }),
   resetFilters: () => set(initialState),
 }))
 
-export type { PriorityFilter, StatusFilter }
+export type { DueDateFilter, PriorityFilter, StatusFilter }


### PR DESCRIPTION
## Summary
- add TaskFilters component with status, priority, due date, and new task button wired to the creation modal store
- add ViewSwitcher segmented control synced with the tasks view store
- extend the tasks filters store to persist due date selections and add a task creation modal store

## Testing
- pnpm --filter @apps/web test *(fails: no test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68e2ce0a217c832baacb10b0d7122fff