### PR TITLE
feat(web): add task views and placeholders

### DIFF
--- a/apps/web/src/features/tasks/components/CardsView.tsx
+++ b/apps/web/src/features/tasks/components/CardsView.tsx
@@ -1,0 +1,52 @@
+import { type Task } from '@contracts'
+
+import { cn } from '@/lib/utils'
+
+import { EmptyState } from './EmptyState'
+import { LoadingSkeleton } from './LoadingSkeleton'
+import { TaskCard } from './TaskCard'
+
+interface CardsViewProps {
+  tasks: Task[]
+  isLoading?: boolean
+  className?: string
+  onSelectTask?: (task: Task) => void
+  onCreateFirstTask?: () => void
+}
+
+export function CardsView({
+  tasks,
+  isLoading = false,
+  className,
+  onSelectTask,
+  onCreateFirstTask,
+}: CardsViewProps) {
+  if (isLoading) {
+    return (
+      <div className={cn('grid gap-4 md:hidden', className)}>
+        {Array.from({ length: 3 }).map((_, index) => (
+          <LoadingSkeleton key={index} />
+        ))}
+      </div>
+    )
+  }
+
+  if (tasks.length === 0) {
+    return (
+      <EmptyState
+        title="Você ainda não possui tarefas"
+        description="Crie sua primeira tarefa para visualizar o progresso por aqui."
+        onAction={onCreateFirstTask}
+        className="md:hidden"
+      />
+    )
+  }
+
+  return (
+    <div className={cn('grid gap-4 md:hidden', className)}>
+      {tasks.map((task) => (
+        <TaskCard key={task.id} task={task} onSelect={onSelectTask} />
+      ))}
+    </div>
+  )
+}

--- a/apps/web/src/features/tasks/components/EmptyState.tsx
+++ b/apps/web/src/features/tasks/components/EmptyState.tsx
@@ -1,0 +1,44 @@
+import { ClipboardList } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+
+interface EmptyStateProps {
+  title?: string
+  description?: string
+  className?: string
+  onAction?: () => void
+  actionLabel?: string
+}
+
+export function EmptyState({
+  title = 'Nada por aqui ainda',
+  description = 'Comece criando uma tarefa para acompanhar o trabalho da sua equipe.',
+  className,
+  onAction,
+  actionLabel = 'Criar primeira tarefa',
+}: EmptyStateProps) {
+  return (
+    <div
+      className={cn(
+        'flex flex-col items-center justify-center gap-4 rounded-lg border border-dashed border-border bg-card/60 p-8 text-center',
+        className,
+      )}
+    >
+      <div className="flex size-12 items-center justify-center rounded-full bg-muted/60 text-muted-foreground">
+        <ClipboardList className="size-6" aria-hidden="true" />
+      </div>
+
+      <div className="space-y-2">
+        <h2 className="text-lg font-semibold text-foreground">{title}</h2>
+        {description ? <p className="text-sm text-muted-foreground">{description}</p> : null}
+      </div>
+
+      {onAction ? (
+        <Button type="button" onClick={onAction} size="sm">
+          {actionLabel}
+        </Button>
+      ) : null}
+    </div>
+  )
+}

--- a/apps/web/src/features/tasks/components/KanbanView.tsx
+++ b/apps/web/src/features/tasks/components/KanbanView.tsx
@@ -1,0 +1,83 @@
+import { type Task, TaskStatus } from '@contracts'
+
+import { cn } from '@/lib/utils'
+
+import { EmptyState } from './EmptyState'
+import { LoadingSkeleton } from './LoadingSkeleton'
+import { TaskCard } from './TaskCard'
+
+const columns: Array<{ status: TaskStatus; label: string }> = [
+  { status: TaskStatus.TODO, label: 'A fazer' },
+  { status: TaskStatus.IN_PROGRESS, label: 'Em andamento' },
+  { status: TaskStatus.REVIEW, label: 'Em revisão' },
+  { status: TaskStatus.DONE, label: 'Concluída' },
+]
+
+interface KanbanViewProps {
+  tasks: Task[]
+  isLoading?: boolean
+  className?: string
+  onSelectTask?: (task: Task) => void
+  onCreateFirstTask?: () => void
+}
+
+export function KanbanView({
+  tasks,
+  isLoading = false,
+  className,
+  onSelectTask,
+  onCreateFirstTask,
+}: KanbanViewProps) {
+  const hasTasks = tasks.length > 0
+
+  if (!hasTasks && !isLoading) {
+    return (
+      <EmptyState
+        title="Nenhuma tarefa por aqui"
+        description="Organize seu fluxo de trabalho criando tarefas e acompanhando o progresso em cada coluna."
+        onAction={onCreateFirstTask}
+        className="hidden md:flex"
+      />
+    )
+  }
+
+  return (
+    <div className={cn('hidden gap-6 md:grid md:grid-cols-2 lg:grid-cols-4', className)}>
+      {columns.map((column) => {
+        const columnTasks = tasks.filter((task) => task.status === column.status)
+
+        return (
+          <section
+            key={column.status}
+            className="flex min-h-[320px] flex-col gap-4 rounded-lg border border-dashed border-border bg-card/40 p-4"
+          >
+            <header className="flex items-center justify-between gap-2">
+              <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+                {column.label}
+              </h2>
+              <span className="rounded-full bg-muted px-2 py-0.5 text-xs font-semibold text-muted-foreground">
+                {columnTasks.length}
+              </span>
+            </header>
+
+            <div className="flex flex-1 flex-col gap-3">
+              {isLoading ? (
+                Array.from({ length: 2 }).map((_, index) => (
+                  <LoadingSkeleton key={index} />
+                ))
+              ) : columnTasks.length > 0 ? (
+                columnTasks.map((task) => (
+                  <TaskCard key={task.id} task={task} onSelect={onSelectTask} />
+                ))
+              ) : (
+                <p className="rounded-lg border border-dashed border-border bg-background/40 p-6 text-center text-sm text-muted-foreground">
+                  Nenhuma tarefa nesta coluna
+                </p>
+              )}
+            </div>
+          </section>
+        )
+      })}
+    </div>
+  )
+}

--- a/apps/web/src/features/tasks/components/LoadingSkeleton.tsx
+++ b/apps/web/src/features/tasks/components/LoadingSkeleton.tsx
@@ -1,0 +1,33 @@
+import { cn } from '@/lib/utils'
+
+interface LoadingSkeletonProps {
+  lines?: number
+  className?: string
+}
+
+export function LoadingSkeleton({ lines = 3, className }: LoadingSkeletonProps) {
+  const placeholders = Array.from({ length: lines })
+
+  return (
+    <div
+      className={cn(
+        'relative overflow-hidden rounded-lg border border-border bg-card/80 p-4 shadow-sm animate-shimmer',
+        className,
+      )}
+    >
+      <div className="space-y-3">
+        {placeholders.map((_, index) => (
+          <div
+            key={index}
+            className="h-3 rounded bg-muted"
+            style={{ width: `${100 - index * 15}%` }}
+          />
+        ))}
+        <div className="mt-4 flex gap-3">
+          <div className="h-8 w-8 rounded-full bg-muted" />
+          <div className="h-8 flex-1 rounded bg-muted" />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/features/tasks/components/TableView.tsx
+++ b/apps/web/src/features/tasks/components/TableView.tsx
@@ -1,0 +1,113 @@
+import { type Task, TaskPriority, TaskStatus } from '@contracts'
+
+import { cn } from '@/lib/utils'
+
+import { EmptyState } from './EmptyState'
+import { LoadingSkeleton } from './LoadingSkeleton'
+
+const priorityLabels: Record<TaskPriority, string> = {
+  [TaskPriority.LOW]: 'Baixa',
+  [TaskPriority.MEDIUM]: 'Média',
+  [TaskPriority.HIGH]: 'Alta',
+  [TaskPriority.URGENT]: 'Urgente',
+}
+
+const statusLabels: Record<TaskStatus, string> = {
+  [TaskStatus.TODO]: 'A fazer',
+  [TaskStatus.IN_PROGRESS]: 'Em andamento',
+  [TaskStatus.REVIEW]: 'Em revisão',
+  [TaskStatus.DONE]: 'Concluída',
+}
+
+function formatDueDate(dueDate?: string | null) {
+  if (!dueDate) {
+    return 'Sem prazo'
+  }
+
+  const parsedDate = new Date(dueDate)
+
+  if (Number.isNaN(parsedDate.getTime())) {
+    return 'Prazo inválido'
+  }
+
+  return new Intl.DateTimeFormat('pt-BR', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+  }).format(parsedDate)
+}
+
+interface TableViewProps {
+  tasks: Task[]
+  isLoading?: boolean
+  className?: string
+  onSelectTask?: (task: Task) => void
+  onCreateFirstTask?: () => void
+}
+
+export function TableView({
+  tasks,
+  isLoading = false,
+  className,
+  onSelectTask,
+  onCreateFirstTask,
+}: TableViewProps) {
+  if (isLoading) {
+    return (
+      <div className={cn('hidden flex-col gap-3 md:flex', className)}>
+        {Array.from({ length: 3 }).map((_, index) => (
+          <LoadingSkeleton key={index} className="rounded-md" />
+        ))}
+      </div>
+    )
+  }
+
+  if (tasks.length === 0) {
+    return (
+      <EmptyState
+        title="Nenhuma tarefa cadastrada"
+        description="Use o botão abaixo para adicionar a primeira tarefa da sua equipe."
+        onAction={onCreateFirstTask}
+        className="hidden md:flex"
+      />
+    )
+  }
+
+  return (
+    <div className={cn('hidden overflow-hidden rounded-lg border border-border md:block', className)}>
+      <table className="w-full border-collapse text-sm">
+        <thead className="bg-muted/50 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          <tr>
+            <th className="px-4 py-3">Título</th>
+            <th className="px-4 py-3">Prioridade</th>
+            <th className="px-4 py-3">Responsáveis</th>
+            <th className="px-4 py-3">Prazo</th>
+            <th className="px-4 py-3">Status</th>
+          </tr>
+        </thead>
+        <tbody>
+          {tasks.map((task) => (
+            <tr
+              key={task.id}
+              className={cn(
+                'border-t border-border text-sm transition-colors hover:bg-muted/30',
+                onSelectTask && 'cursor-pointer',
+              )}
+              onClick={onSelectTask ? () => onSelectTask(task) : undefined}
+            >
+              <td className="px-4 py-3 font-medium text-foreground">{task.title}</td>
+              <td className="px-4 py-3">{priorityLabels[task.priority]}</td>
+              <td className="px-4 py-3 text-muted-foreground">
+                {task.assignees.length > 0
+                  ? task.assignees.map((assignee) => assignee.username).join(', ')
+                  : 'Sem responsáveis'}
+              </td>
+              <td className="px-4 py-3 text-muted-foreground">{formatDueDate(task.dueDate)}</td>
+              <td className="px-4 py-3 text-muted-foreground">{statusLabels[task.status]}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/apps/web/src/features/tasks/components/TaskCard.tsx
+++ b/apps/web/src/features/tasks/components/TaskCard.tsx
@@ -1,0 +1,119 @@
+import { type KeyboardEvent } from 'react'
+import { CalendarDays, Users } from 'lucide-react'
+import { type Task, TaskPriority } from '@contracts'
+
+import { cn } from '@/lib/utils'
+
+const priorityLabels: Record<TaskPriority, string> = {
+  [TaskPriority.LOW]: 'Baixa',
+  [TaskPriority.MEDIUM]: 'Média',
+  [TaskPriority.HIGH]: 'Alta',
+  [TaskPriority.URGENT]: 'Urgente',
+}
+
+const priorityStyles: Record<TaskPriority, string> = {
+  [TaskPriority.LOW]:
+    'border-gray-200 bg-gray-100 text-gray-700 dark:border-gray-800 dark:bg-gray-900/60 dark:text-gray-100',
+  [TaskPriority.MEDIUM]:
+    'border-blue-200 bg-blue-100 text-blue-700 dark:border-blue-500/30 dark:bg-blue-500/10 dark:text-blue-200',
+  [TaskPriority.HIGH]:
+    'border-orange-200 bg-orange-100 text-orange-700 dark:border-orange-500/30 dark:bg-orange-500/10 dark:text-orange-200',
+  [TaskPriority.URGENT]:
+    'border-red-200 bg-red-100 text-red-700 dark:border-red-500/30 dark:bg-red-500/10 dark:text-red-200',
+}
+
+interface TaskCardProps {
+  task: Task
+  className?: string
+  onSelect?: (task: Task) => void
+}
+
+function formatDueDate(dueDate?: string | null) {
+  if (!dueDate) {
+    return 'Sem prazo definido'
+  }
+
+  const parsedDate = new Date(dueDate)
+
+  if (Number.isNaN(parsedDate.getTime())) {
+    return 'Prazo inválido'
+  }
+
+  return new Intl.DateTimeFormat('pt-BR', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+  }).format(parsedDate)
+}
+
+function getBadgeClassName(priority: TaskPriority) {
+  return cn(
+    'inline-flex items-center rounded-full border px-3 py-1 text-xs font-semibold uppercase tracking-wide',
+    priorityStyles[priority],
+  )
+}
+
+export function TaskCard({ task, className, onSelect }: TaskCardProps) {
+  const isInteractive = Boolean(onSelect)
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (!isInteractive) {
+      return
+    }
+
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault()
+      onSelect?.(task)
+    }
+  }
+
+  return (
+    <article
+      role={isInteractive ? 'button' : undefined}
+      tabIndex={isInteractive ? 0 : undefined}
+      onClick={isInteractive ? () => onSelect?.(task) : undefined}
+      onKeyDown={handleKeyDown}
+      className={cn(
+        'flex flex-col gap-4 rounded-lg border border-border bg-card p-4 shadow-sm transition-shadow focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 hover:shadow-md',
+        isInteractive && 'cursor-pointer',
+        className,
+      )}
+    >
+      <div className="flex items-start justify-between gap-4">
+        <div className="space-y-2">
+          <h3 className="text-base font-semibold text-foreground">{task.title}</h3>
+          {task.description ? (
+            <p className="text-sm text-muted-foreground">{task.description}</p>
+          ) : null}
+        </div>
+
+        <span className={getBadgeClassName(task.priority)}>{priorityLabels[task.priority]}</span>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-x-6 gap-y-3 text-sm text-muted-foreground">
+        <div className="flex items-center gap-2">
+          <CalendarDays className="size-4" aria-hidden="true" />
+          <span>{formatDueDate(task.dueDate)}</span>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <Users className="size-4" aria-hidden="true" />
+          {task.assignees.length > 0 ? (
+            <div className="flex flex-wrap items-center gap-2">
+              {task.assignees.map((assignee) => (
+                <span
+                  key={assignee.id}
+                  className="rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground"
+                >
+                  {assignee.username}
+                </span>
+              ))}
+            </div>
+          ) : (
+            <span>Sem responsáveis</span>
+          )}
+        </div>
+      </div>
+    </article>
+  )
+}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -136,3 +136,28 @@ code {
     @apply bg-background text-foreground;
   }
 }
+
+@keyframes shimmer {
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(100%);
+  }
+}
+
+@layer utilities {
+  .animate-shimmer::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background-image: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.6), transparent);
+    transform: translateX(-100%);
+    animation: shimmer 1.8s linear infinite;
+  }
+
+  .dark .animate-shimmer::after {
+    background-image: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.12), transparent);
+  }
+}


### PR DESCRIPTION
## Summary
- create a reusable TaskCard component with priority badge, due date, and assignee chips
- add responsive task views (cards, table, kanban) that reuse TaskCard and handle loading/empty states
- introduce LoadingSkeleton with shimmer effect and EmptyState CTA for first task creation

## Testing
- pnpm --filter @apps/web test *(fails: vitest exits because no test files are defined)*
- pnpm --filter @apps/web build *(fails: existing project issue resolving @radix-ui/react-toast during Vite build)*

------
https://chatgpt.com/codex/tasks/task_e_68e2d3f8fb64832b8b9aeb022834dde1