### PR TITLE
feat: add tasks list and detail pages

### DIFF
--- a/apps/web/src/features/tasks/api/getTaskById.ts
+++ b/apps/web/src/features/tasks/api/getTaskById.ts
@@ -1,0 +1,22 @@
+import type { Task } from '@contracts'
+
+import { taskSchema } from '../schemas/taskSchema'
+import { TASKS_ENDPOINT } from './getTasks'
+
+export async function getTaskById(taskId: string): Promise<Task> {
+  const response = await fetch(`${TASKS_ENDPOINT}/${taskId}`, {
+    method: 'GET',
+    credentials: 'include',
+  })
+
+  if (!response.ok) {
+    throw new Error(
+      `Falha ao carregar tarefa: ${response.status} ${response.statusText}`,
+    )
+  }
+
+  const data = await response.json()
+  const payload = 'data' in data ? data.data : data
+
+  return taskSchema.parse(payload)
+}

--- a/apps/web/src/features/tasks/api/getTaskComments.ts
+++ b/apps/web/src/features/tasks/api/getTaskComments.ts
@@ -1,0 +1,22 @@
+import type { CommentDTO } from '@contracts'
+
+import { commentSchema } from '../schemas/commentSchema'
+import { TASKS_ENDPOINT } from './getTasks'
+
+export async function getTaskComments(taskId: string): Promise<CommentDTO[]> {
+  const response = await fetch(`${TASKS_ENDPOINT}/${taskId}/comments`, {
+    method: 'GET',
+    credentials: 'include',
+  })
+
+  if (!response.ok) {
+    throw new Error(
+      `Falha ao carregar comentários: ${response.status} ${response.statusText}`,
+    )
+  }
+
+  const data = await response.json()
+  const payload = 'data' in data ? data.data : data
+
+  return commentSchema.array().parse(payload)
+}

--- a/apps/web/src/features/tasks/api/getTaskNotifications.ts
+++ b/apps/web/src/features/tasks/api/getTaskNotifications.ts
@@ -1,0 +1,24 @@
+import type { NotificationDTO } from '@contracts'
+
+import { notificationSchema } from '../schemas/notificationSchema'
+import { TASKS_ENDPOINT } from './getTasks'
+
+export async function getTaskNotifications(
+  taskId: string,
+): Promise<NotificationDTO[]> {
+  const response = await fetch(`${TASKS_ENDPOINT}/${taskId}/notifications`, {
+    method: 'GET',
+    credentials: 'include',
+  })
+
+  if (!response.ok) {
+    throw new Error(
+      `Falha ao carregar notificações: ${response.status} ${response.statusText}`,
+    )
+  }
+
+  const data = await response.json()
+  const payload = 'data' in data ? data.data : data
+
+  return notificationSchema.array().parse(payload)
+}

--- a/apps/web/src/features/tasks/api/getTasks.ts
+++ b/apps/web/src/features/tasks/api/getTasks.ts
@@ -1,4 +1,5 @@
-import type { Task } from '@contracts'
+import type { Task, TaskPriority, TaskStatus } from '@contracts'
+import { z } from 'zod'
 
 import { env } from '@/env'
 
@@ -7,8 +8,48 @@ import { taskSchema } from '../schemas/taskSchema'
 const API_BASE_URL = env.VITE_API_BASE_URL?.replace(/\/$/, '') ?? ''
 const TASKS_ENDPOINT = API_BASE_URL ? `${API_BASE_URL}/tasks` : '/api/tasks'
 
-export async function getTasks(): Promise<Task[]> {
-  const response = await fetch(TASKS_ENDPOINT, {
+const paginatedTasksSchema = z.object({
+  data: taskSchema.array(),
+})
+
+interface GetTasksFilters {
+  status?: TaskStatus | 'ALL'
+  priority?: TaskPriority | 'ALL'
+  searchTerm?: string | null
+  dueDate?: string | null
+}
+
+function buildTasksUrl(filters?: GetTasksFilters) {
+  const params = new URLSearchParams()
+
+  if (filters?.status && filters.status !== 'ALL') {
+    params.set('status', filters.status)
+  }
+
+  if (filters?.priority && filters.priority !== 'ALL') {
+    params.set('priority', filters.priority)
+  }
+
+  const searchTerm = filters?.searchTerm?.trim()
+  if (searchTerm) {
+    params.set('search', searchTerm)
+  }
+
+  const query = params.toString()
+
+  return query ? `${TASKS_ENDPOINT}?${query}` : TASKS_ENDPOINT
+}
+
+function matchesDueDate(task: Task, dueDate: string) {
+  if (!task.dueDate) {
+    return false
+  }
+
+  return task.dueDate.slice(0, 10) === dueDate
+}
+
+export async function getTasks(filters?: GetTasksFilters): Promise<Task[]> {
+  const response = await fetch(buildTasksUrl(filters), {
     method: 'GET',
     credentials: 'include',
   })
@@ -20,8 +61,15 @@ export async function getTasks(): Promise<Task[]> {
   }
 
   const data = await response.json()
+  const parsed = paginatedTasksSchema.parse(data)
 
-  return taskSchema.array().parse(data)
+  if (filters?.dueDate) {
+    const dueDate = filters.dueDate
+    return parsed.data.filter((task) => matchesDueDate(task, dueDate))
+  }
+
+  return parsed.data
 }
 
+export type { GetTasksFilters }
 export { TASKS_ENDPOINT }

--- a/apps/web/src/features/tasks/components/SearchBar.tsx
+++ b/apps/web/src/features/tasks/components/SearchBar.tsx
@@ -82,12 +82,14 @@ interface SearchBarProps {
   className?: string
   placeholder?: string
   onTaskSelect?: (taskId: string) => void
+  onSearchTermChange?: (term: string) => void
 }
 
 export function SearchBar({
   className,
   placeholder = DEFAULT_PLACEHOLDER,
   onTaskSelect = onSelectTask,
+  onSearchTermChange,
 }: SearchBarProps) {
   const [open, setOpen] = useState(false)
   const [searchTerm, setSearchTerm] = useState('')
@@ -102,6 +104,10 @@ export function SearchBar({
       window.clearTimeout(timeout)
     }
   }, [searchTerm])
+
+  useEffect(() => {
+    onSearchTermChange?.(debouncedTerm)
+  }, [debouncedTerm, onSearchTermChange])
 
   const shouldSearch = debouncedTerm.length > 0
 
@@ -140,6 +146,7 @@ export function SearchBar({
     setOpen(false)
     setSearchTerm('')
     setDebouncedTerm('')
+    onSearchTermChange?.('')
   }
 
   return (
@@ -150,7 +157,8 @@ export function SearchBar({
           <Input
             value={searchTerm}
             onChange={(event) => {
-              setSearchTerm(event.target.value)
+              const value = event.target.value
+              setSearchTerm(value)
               if (!open) {
                 setOpen(true)
               }

--- a/apps/web/src/features/tasks/components/TaskModal.tsx
+++ b/apps/web/src/features/tasks/components/TaskModal.tsx
@@ -34,6 +34,7 @@ interface TaskModalProps {
   open: boolean
   onOpenChange: (open: boolean) => void
   task?: Task | null
+  onSuccess?: (task: Task) => void
 }
 
 function formatTaskToFormValues(task?: Task | null): TaskSchema {
@@ -75,7 +76,7 @@ function normalizeFormValues(values: TaskSchema) {
   }
 }
 
-export function TaskModal({ open, onOpenChange, task }: TaskModalProps) {
+export function TaskModal({ open, onOpenChange, task, onSuccess }: TaskModalProps) {
   const queryClient = useQueryClient()
   const isEditing = Boolean(task)
 
@@ -104,10 +105,12 @@ export function TaskModal({ open, onOpenChange, task }: TaskModalProps) {
     },
     onSuccess: (data) => {
       queryClient.invalidateQueries({ queryKey: ['tasks'] })
+      queryClient.invalidateQueries({ queryKey: ['task', data.id] })
       toast({
         title: isEditing ? 'Tarefa atualizada' : 'Tarefa criada',
         description: `A tarefa "${data.title}" foi ${isEditing ? 'atualizada' : 'criada'} com sucesso.`,
       })
+      onSuccess?.(data)
       onOpenChange(false)
       form.reset(formatTaskToFormValues(isEditing ? data : null))
     },

--- a/apps/web/src/features/tasks/pages/TaskDetailsPage.tsx
+++ b/apps/web/src/features/tasks/pages/TaskDetailsPage.tsx
@@ -1,0 +1,373 @@
+import { useState } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { type CommentDTO, type NotificationDTO, TaskPriority, TaskStatus } from '@contracts'
+import { Bell, CalendarDays, MessageSquare, Users } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import { toast } from '@/components/ui/use-toast'
+import { router } from '@/router'
+
+import { deleteTask } from '../api/deleteTask'
+import { getTaskById } from '../api/getTaskById'
+import { getTaskComments } from '../api/getTaskComments'
+import { getTaskNotifications } from '../api/getTaskNotifications'
+import { LoadingSkeleton } from '../components/LoadingSkeleton'
+import { TaskModal } from '../components/TaskModal'
+
+interface TaskDetailsPageProps {
+  taskId: string
+}
+
+const containerClassName =
+  'mx-auto flex w-full max-w-5xl flex-col gap-8 px-4 py-8 sm:px-6 lg:px-8'
+
+const priorityLabels: Record<TaskPriority, string> = {
+  [TaskPriority.LOW]: 'Baixa',
+  [TaskPriority.MEDIUM]: 'Média',
+  [TaskPriority.HIGH]: 'Alta',
+  [TaskPriority.URGENT]: 'Urgente',
+}
+
+const statusLabels: Record<TaskStatus, string> = {
+  [TaskStatus.TODO]: 'A fazer',
+  [TaskStatus.IN_PROGRESS]: 'Em andamento',
+  [TaskStatus.REVIEW]: 'Em revisão',
+  [TaskStatus.DONE]: 'Concluída',
+}
+
+function formatDate(value?: string | null, fallback = 'Não informado') {
+  if (!value) {
+    return fallback
+  }
+
+  const date = new Date(value)
+
+  if (Number.isNaN(date.getTime())) {
+    return fallback
+  }
+
+  return new Intl.DateTimeFormat('pt-BR', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+  }).format(date)
+}
+
+function formatDateTime(value?: string | null) {
+  if (!value) {
+    return '—'
+  }
+
+  const date = new Date(value)
+
+  if (Number.isNaN(date.getTime())) {
+    return '—'
+  }
+
+  return new Intl.DateTimeFormat('pt-BR', {
+    dateStyle: 'short',
+    timeStyle: 'short',
+  }).format(date)
+}
+
+export function TaskDetailsPage({ taskId }: TaskDetailsPageProps) {
+  const queryClient = useQueryClient()
+  const [isEditing, setIsEditing] = useState(false)
+
+  const taskQuery = useQuery({
+    queryKey: ['task', taskId],
+    queryFn: () => getTaskById(taskId),
+  })
+
+  const commentsQuery = useQuery({
+    queryKey: ['task', taskId, 'comments'],
+    queryFn: () => getTaskComments(taskId),
+    enabled: taskQuery.isSuccess,
+  })
+
+  const notificationsQuery = useQuery({
+    queryKey: ['task', taskId, 'notifications'],
+    queryFn: () => getTaskNotifications(taskId),
+    enabled: taskQuery.isSuccess,
+  })
+
+  const deleteMutation = useMutation({
+    mutationFn: () => deleteTask(taskId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['tasks'] })
+      queryClient.removeQueries({ queryKey: ['task', taskId] })
+      toast({
+        title: 'Tarefa removida',
+        description: 'A tarefa foi removida com sucesso.',
+      })
+      void router.navigate({ to: '/tasks' })
+    },
+    onError: (error: unknown) => {
+      const description =
+        error instanceof Error
+          ? error.message
+          : 'Não foi possível remover a tarefa. Tente novamente.'
+
+      toast({
+        variant: 'destructive',
+        title: 'Erro ao remover tarefa',
+        description,
+      })
+    },
+  })
+
+  if (taskQuery.isPending) {
+    return (
+      <main className={containerClassName}>
+        <LoadingSkeleton className="h-24" />
+        <LoadingSkeleton className="h-64" />
+      </main>
+    )
+  }
+
+  if (taskQuery.isError) {
+    const message =
+      taskQuery.error instanceof Error
+        ? taskQuery.error.message
+        : 'Não foi possível carregar a tarefa selecionada.'
+
+    return (
+      <main className={containerClassName}>
+        <div className="space-y-4 rounded-lg border border-destructive/30 bg-destructive/10 p-6 text-destructive">
+          <div className="space-y-1">
+            <h1 className="text-lg font-semibold">Erro ao carregar tarefa</h1>
+            <p className="text-sm text-destructive/80">{message}</p>
+          </div>
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            onClick={() => taskQuery.refetch()}
+            className="w-fit"
+          >
+            Tentar novamente
+          </Button>
+        </div>
+      </main>
+    )
+  }
+
+  const task = taskQuery.data
+
+  const comments = commentsQuery.data ?? []
+  const notifications = notificationsQuery.data ?? []
+
+  const commentsError =
+    commentsQuery.isError &&
+    (commentsQuery.error instanceof Error
+      ? commentsQuery.error.message
+      : 'Não foi possível carregar os comentários.')
+
+  const notificationsError =
+    notificationsQuery.isError &&
+    (notificationsQuery.error instanceof Error
+      ? notificationsQuery.error.message
+      : 'Não foi possível carregar as notificações.')
+
+  return (
+    <main className={containerClassName}>
+      <header className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div className="space-y-3">
+          <button
+            type="button"
+            onClick={() => void router.navigate({ to: '/tasks' })}
+            className="text-sm font-medium text-primary transition-colors hover:text-primary/80"
+          >
+            ← Voltar para lista de tarefas
+          </button>
+          <div className="space-y-2">
+            <h1 className="text-2xl font-semibold tracking-tight text-foreground sm:text-3xl">
+              {task.title}
+            </h1>
+            {task.description ? (
+              <p className="text-sm text-muted-foreground max-w-3xl">
+                {task.description}
+              </p>
+            ) : null}
+          </div>
+
+          <div className="flex flex-wrap items-center gap-4 text-sm text-muted-foreground">
+            <span>
+              Status:
+              <strong className="ml-2 font-semibold text-foreground">
+                {statusLabels[task.status]}
+              </strong>
+            </span>
+            <span>
+              Prioridade:
+              <strong className="ml-2 font-semibold text-foreground">
+                {priorityLabels[task.priority]}
+              </strong>
+            </span>
+            <span>
+              Prazo:
+              <strong className="ml-2 font-semibold text-foreground">
+                {formatDate(task.dueDate, 'Sem prazo definido')}
+              </strong>
+            </span>
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-2 sm:flex-row">
+          <Button type="button" variant="outline" onClick={() => setIsEditing(true)}>
+            Editar tarefa
+          </Button>
+          <Button
+            type="button"
+            variant="destructive"
+            onClick={() => deleteMutation.mutate()}
+            disabled={deleteMutation.isPending}
+          >
+            {deleteMutation.isPending ? 'Removendo...' : 'Excluir tarefa'}
+          </Button>
+        </div>
+      </header>
+
+      <section className="grid gap-6 rounded-lg border border-border bg-card/60 p-6 shadow-sm sm:grid-cols-2">
+        <div className="space-y-4">
+          <h2 className="flex items-center gap-2 text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+            <CalendarDays className="size-4" aria-hidden="true" />
+            Datas importantes
+          </h2>
+          <ul className="space-y-2 text-sm text-muted-foreground">
+            <li>
+              <strong className="font-medium text-foreground">Criada em:</strong>{' '}
+              {formatDateTime(task.createdAt)}
+            </li>
+            <li>
+              <strong className="font-medium text-foreground">Atualizada em:</strong>{' '}
+              {formatDateTime(task.updatedAt)}
+            </li>
+            <li>
+              <strong className="font-medium text-foreground">Prazo:</strong>{' '}
+              {formatDate(task.dueDate, 'Sem prazo definido')}
+            </li>
+          </ul>
+        </div>
+
+        <div className="space-y-4">
+          <h2 className="flex items-center gap-2 text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+            <Users className="size-4" aria-hidden="true" />
+            Responsáveis
+          </h2>
+          {task.assignees.length > 0 ? (
+            <ul className="flex flex-col gap-2 text-sm text-muted-foreground">
+              {task.assignees.map((assignee) => (
+                <li key={assignee.id} className="flex items-center justify-between rounded-md bg-muted/60 px-3 py-2 text-foreground">
+                  <span>{assignee.username}</span>
+                  <span className="text-xs text-muted-foreground">ID: {assignee.id}</span>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="text-sm text-muted-foreground">Nenhum responsável atribuído.</p>
+          )}
+        </div>
+      </section>
+
+      <section className="grid gap-6 lg:grid-cols-2">
+        <div className="flex flex-col gap-4 rounded-lg border border-border bg-card/60 p-6 shadow-sm">
+          <header className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <MessageSquare className="size-4 text-muted-foreground" aria-hidden="true" />
+              <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+                Comentários
+              </h2>
+            </div>
+            {commentsQuery.isFetching ? (
+              <span className="text-xs text-muted-foreground">Atualizando...</span>
+            ) : null}
+          </header>
+
+          {commentsQuery.isPending ? (
+            <div className="space-y-3">
+              <LoadingSkeleton className="h-16" />
+              <LoadingSkeleton className="h-16" />
+            </div>
+          ) : commentsError ? (
+            <p className="text-sm text-destructive">{commentsError}</p>
+          ) : comments.length > 0 ? (
+            <ul className="space-y-4">
+              {comments.map((comment: CommentDTO) => (
+                <li key={comment.id} className="rounded-md border border-border bg-background/80 p-4">
+                  <div className="flex items-center justify-between text-xs text-muted-foreground">
+                    <span>Autor: {comment.authorId}</span>
+                    <span>{formatDateTime(comment.createdAt)}</span>
+                  </div>
+                  <p className="mt-2 text-sm text-foreground">{comment.message}</p>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              Nenhum comentário registrado para esta tarefa.
+            </p>
+          )}
+        </div>
+
+        <div className="flex flex-col gap-4 rounded-lg border border-border bg-card/60 p-6 shadow-sm">
+          <header className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <Bell className="size-4 text-muted-foreground" aria-hidden="true" />
+              <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+                Notificações
+              </h2>
+            </div>
+            {notificationsQuery.isFetching ? (
+              <span className="text-xs text-muted-foreground">Atualizando...</span>
+            ) : null}
+          </header>
+
+          {notificationsQuery.isPending ? (
+            <div className="space-y-3">
+              <LoadingSkeleton className="h-16" />
+              <LoadingSkeleton className="h-16" />
+            </div>
+          ) : notificationsError ? (
+            <p className="text-sm text-destructive">{notificationsError}</p>
+          ) : notifications.length > 0 ? (
+            <ul className="space-y-4">
+              {notifications.map((notification: NotificationDTO) => (
+                <li key={notification.id} className="rounded-md border border-border bg-background/80 p-4">
+                  <div className="flex items-center justify-between text-xs text-muted-foreground">
+                    <span>Canal: {notification.channel}</span>
+                    <span>Status: {notification.status}</span>
+                  </div>
+                  <p className="mt-2 text-sm text-foreground">{notification.message}</p>
+                  <div className="mt-3 flex flex-wrap gap-4 text-xs text-muted-foreground">
+                    <span>Criada: {formatDateTime(notification.createdAt)}</span>
+                    <span>
+                      Enviada:{' '}
+                      {notification.sentAt
+                        ? formatDateTime(notification.sentAt)
+                        : 'Não enviada'}
+                    </span>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              Nenhuma notificação registrada para esta tarefa.
+            </p>
+          )}
+        </div>
+      </section>
+
+      <TaskModal
+        open={isEditing}
+        onOpenChange={setIsEditing}
+        task={task}
+        onSuccess={(updatedTask) => {
+          setIsEditing(false)
+          queryClient.setQueryData(['task', updatedTask.id], updatedTask)
+        }}
+      />
+    </main>
+  )
+}

--- a/apps/web/src/features/tasks/pages/TasksPage.tsx
+++ b/apps/web/src/features/tasks/pages/TasksPage.tsx
@@ -1,0 +1,149 @@
+import { useMemo } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import type { Task } from '@contracts'
+
+import { Button } from '@/components/ui/button'
+import { router } from '@/router'
+
+import { getTasks, type GetTasksFilters } from '../api/getTasks'
+import { CardsView } from '../components/CardsView'
+import { KanbanView } from '../components/KanbanView'
+import { SearchBar } from '../components/SearchBar'
+import { TableView } from '../components/TableView'
+import { TaskFilters } from '../components/TaskFilters'
+import { TaskModal } from '../components/TaskModal'
+import { ViewSwitcher } from '../components/ViewSwitcher'
+import { useTaskCreationModal } from '../store/useTaskCreationModal'
+import { useTasksFilters } from '../store/useTasksFilters'
+import { useTasksView } from '../store/useTasksView'
+
+const containerClassName =
+  'mx-auto flex w-full max-w-6xl flex-col gap-6 px-4 py-8 sm:px-6 lg:px-8'
+
+const sectionTitleClassName =
+  'text-2xl font-semibold tracking-tight text-foreground sm:text-3xl'
+
+export function TasksPage() {
+  const {
+    status,
+    priority,
+    dueDate,
+    searchTerm,
+    setSearchTerm,
+  } = useTasksFilters()
+  const { viewMode } = useTasksView()
+  const creationModal = useTaskCreationModal()
+
+  const filters = useMemo<Pick<GetTasksFilters, 'status' | 'priority' | 'dueDate' | 'searchTerm'>>(
+    () => ({ status, priority, dueDate, searchTerm }),
+    [status, priority, dueDate, searchTerm],
+  )
+
+  const tasksQuery = useQuery({
+    queryKey: ['tasks', filters],
+    queryFn: () => getTasks(filters),
+  })
+
+  const tasks = tasksQuery.data ?? []
+  const isPending = tasksQuery.isPending
+  const isFetching = tasksQuery.isFetching
+  const isLoading = isPending || (isFetching && tasks.length === 0)
+  const isRefetching = isFetching && !isPending
+
+  const handleTaskSelect = (task: Task) => {
+    void router.navigate({
+      to: '/tasks/$taskId',
+      params: { taskId: task.id },
+    })
+  }
+
+  const isModalOpen = creationModal.isOpen
+
+  const errorMessage =
+    tasksQuery.isError && tasksQuery.error instanceof Error
+      ? tasksQuery.error.message
+      : tasksQuery.isError
+        ? 'Não foi possível carregar as tarefas. Tente novamente.'
+        : null
+
+  return (
+    <main className={containerClassName}>
+      <header className="space-y-2">
+        <h1 className={sectionTitleClassName}>Tarefas</h1>
+        <p className="max-w-2xl text-sm text-muted-foreground">
+          Acompanhe o progresso das tarefas da sua equipe, filtre por status ou
+          prioridade e visualize os detalhes com facilidade.
+        </p>
+      </header>
+
+      <TaskFilters className="shadow-sm" />
+
+      <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <SearchBar
+          className="w-full md:max-w-md"
+          onTaskSelect={(taskId) => {
+            void router.navigate({
+              to: '/tasks/$taskId',
+              params: { taskId },
+            })
+          }}
+          onSearchTermChange={setSearchTerm}
+        />
+
+        <ViewSwitcher className="md:self-end" />
+      </div>
+
+      {errorMessage ? (
+        <div className="flex flex-col gap-3 rounded-lg border border-destructive/30 bg-destructive/10 p-4 text-destructive">
+          <div className="space-y-1">
+            <h2 className="text-sm font-semibold">Erro ao carregar tarefas</h2>
+            <p className="text-sm text-destructive/80">{errorMessage}</p>
+          </div>
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            onClick={() => tasksQuery.refetch()}
+            className="w-fit"
+          >
+            Tentar novamente
+          </Button>
+        </div>
+      ) : null}
+
+      <section className="space-y-6">
+        <CardsView
+          tasks={tasks}
+          isLoading={isLoading}
+          onSelectTask={handleTaskSelect}
+          onCreateFirstTask={creationModal.open}
+        />
+
+        {viewMode === 'list' ? (
+          <TableView
+            tasks={tasks}
+            isLoading={isLoading && !isRefetching}
+            onSelectTask={handleTaskSelect}
+            onCreateFirstTask={creationModal.open}
+          />
+        ) : (
+          <KanbanView
+            tasks={tasks}
+            isLoading={isLoading}
+            onSelectTask={handleTaskSelect}
+            onCreateFirstTask={creationModal.open}
+          />
+      )}
+      </section>
+
+      <TaskModal
+        open={isModalOpen}
+        onOpenChange={(open) => {
+          if (!open) {
+            creationModal.close()
+          }
+        }}
+      />
+    </main>
+  )
+}

--- a/apps/web/src/features/tasks/schemas/commentSchema.ts
+++ b/apps/web/src/features/tasks/schemas/commentSchema.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod'
+
+export const commentSchema = z.object({
+  id: z.string(),
+  taskId: z.string(),
+  authorId: z.string(),
+  message: z.string(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+})
+
+export type CommentSchema = z.infer<typeof commentSchema>

--- a/apps/web/src/features/tasks/schemas/notificationSchema.ts
+++ b/apps/web/src/features/tasks/schemas/notificationSchema.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod'
+
+export const notificationSchema = z.object({
+  id: z.string(),
+  recipientId: z.string(),
+  channel: z.string(),
+  status: z.string(),
+  message: z.string(),
+  metadata: z.record(z.unknown()).nullish(),
+  createdAt: z.string(),
+  sentAt: z.string().nullish(),
+})
+
+export type NotificationSchema = z.infer<typeof notificationSchema>

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -11,6 +11,8 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as AuthRouteImport } from './routes/auth'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as TasksIndexRouteImport } from './routes/tasks/index'
+import { Route as TasksTaskIdRouteImport } from './routes/tasks/$taskId'
 
 const AuthRoute = AuthRouteImport.update({
   id: '/auth',
@@ -22,31 +24,49 @@ const IndexRoute = IndexRouteImport.update({
   path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const TasksIndexRoute = TasksIndexRouteImport.update({
+  id: '/tasks/',
+  path: '/tasks/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const TasksTaskIdRoute = TasksTaskIdRouteImport.update({
+  id: '/tasks/$taskId',
+  path: '/tasks/$taskId',
+  getParentRoute: () => rootRouteImport,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/auth': typeof AuthRoute
+  '/tasks/$taskId': typeof TasksTaskIdRoute
+  '/tasks': typeof TasksIndexRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/auth': typeof AuthRoute
+  '/tasks/$taskId': typeof TasksTaskIdRoute
+  '/tasks': typeof TasksIndexRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/auth': typeof AuthRoute
+  '/tasks/$taskId': typeof TasksTaskIdRoute
+  '/tasks/': typeof TasksIndexRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/auth'
+  fullPaths: '/' | '/auth' | '/tasks/$taskId' | '/tasks'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/auth'
-  id: '__root__' | '/' | '/auth'
+  to: '/' | '/auth' | '/tasks/$taskId' | '/tasks'
+  id: '__root__' | '/' | '/auth' | '/tasks/$taskId' | '/tasks/'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   AuthRoute: typeof AuthRoute
+  TasksTaskIdRoute: typeof TasksTaskIdRoute
+  TasksIndexRoute: typeof TasksIndexRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -65,12 +85,28 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/tasks/': {
+      id: '/tasks/'
+      path: '/tasks'
+      fullPath: '/tasks'
+      preLoaderRoute: typeof TasksIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/tasks/$taskId': {
+      id: '/tasks/$taskId'
+      path: '/tasks/$taskId'
+      fullPath: '/tasks/$taskId'
+      preLoaderRoute: typeof TasksTaskIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
   }
 }
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   AuthRoute: AuthRoute,
+  TasksTaskIdRoute: TasksTaskIdRoute,
+  TasksIndexRoute: TasksIndexRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/apps/web/src/routes/tasks/$taskId.tsx
+++ b/apps/web/src/routes/tasks/$taskId.tsx
@@ -1,0 +1,13 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import { TaskDetailsPage } from '@/features/tasks/pages/TaskDetailsPage'
+
+export const Route = createFileRoute('/tasks/$taskId')({
+  component: TaskDetailsRoute,
+})
+
+function TaskDetailsRoute() {
+  const { taskId } = Route.useParams()
+
+  return <TaskDetailsPage taskId={taskId} />
+}

--- a/apps/web/src/routes/tasks/index.tsx
+++ b/apps/web/src/routes/tasks/index.tsx
@@ -1,0 +1,11 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import { TasksPage } from '@/features/tasks/pages/TasksPage'
+
+export const Route = createFileRoute('/tasks/')({
+  component: TasksRoute,
+})
+
+function TasksRoute() {
+  return <TasksPage />
+}


### PR DESCRIPTION
## Summary
- add a `/tasks` route that composes filters, search, view switching and responsive task listings driven by React Query
- introduce a `/tasks/$taskId` detail route that loads comments and notifications alongside edit/delete actions
- extend the task data layer with dedicated fetchers, schemas and modal/query enhancements for create/edit flows

## Testing
- `pnpm --filter @apps/web build` *(fails: missing @radix-ui/react-toast dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68e2d5b52b6c832b82538bbd9d3dc720