### PR TITLE
Ensure DATABASE_URL is validated before initializing TypeORM

### DIFF
--- a/apps/auth/src/app.module.ts
+++ b/apps/auth/src/app.module.ts
@@ -6,6 +6,15 @@ import { UsersModule } from './users/users.module';
 import { User } from './users/entities/user.entity';
 import { AuthModule } from './auth/auth.module';
 
+const validateEnv = (config: Record<string, unknown>) => {
+  const databaseUrl = config['DATABASE_URL'];
+
+  if (typeof databaseUrl !== 'string' || databaseUrl.trim().length === 0) {
+    throw new Error('DATABASE_URL must be defined as a non-empty string');
+  }
+
+  return config;
+};
 
 @Module({
   imports: [
@@ -13,12 +22,13 @@ import { AuthModule } from './auth/auth.module';
     ConfigModule.forRoot({
       isGlobal: true,
       envFilePath: ['.env'],
+      validate: validateEnv,
     }),
     TypeOrmModule.forRootAsync({
       inject: [ConfigService],
       useFactory: (cfg: ConfigService) => ({
         type: 'postgres',
-        url: cfg.get<string>('DATABASE_URL'),
+        url: cfg.getOrThrow<string>('DATABASE_URL'),
         autoLoadEntities: true,
         synchronize: true,
         migrationsRun: true,

--- a/apps/tasks/src/app.module.ts
+++ b/apps/tasks/src/app.module.ts
@@ -5,18 +5,29 @@ import { HealthModule } from './health/health.module';
 import { TasksModule } from './tasks/tasks.module';
 import { Task } from './tasks/task.entity';
 
+const validateEnv = (config: Record<string, unknown>) => {
+  const databaseUrl = config['DATABASE_URL'];
+
+  if (typeof databaseUrl !== 'string' || databaseUrl.trim().length === 0) {
+    throw new Error('DATABASE_URL must be defined as a non-empty string');
+  }
+
+  return config;
+};
+
 @Module({
   imports: [
     ConfigModule.forRoot({
       isGlobal: true,
       envFilePath: ['.env'],
+      validate: validateEnv,
     }),
     TypeOrmModule.forRootAsync({
       imports: [ConfigModule],
       inject: [ConfigService],
       useFactory: (configService: ConfigService) => ({
         type: 'postgres',
-        url: configService.get<string>('DATABASE_URL'),
+        url: configService.getOrThrow<string>('DATABASE_URL'),
         autoLoadEntities: true,
         synchronize: false,
         entities: [Task],


### PR DESCRIPTION
## Summary
- add runtime validation to guarantee DATABASE_URL is present and non-empty in the auth and tasks services
- use ConfigService.getOrThrow to avoid passing undefined connection URLs to the TypeORM postgres driver

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2fbac4918832b876f0a90759c2aba