### PR TITLE
docs: update environment examples for services

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,6 +1,26 @@
 # API Gateway environment variables
 NODE_ENV=development
 PORT=3001
-CORS_ORIGIN=http://localhost:3000
+
+# Rate limiting configuration
+RATE_LIMIT_TTL=60
+RATE_LIMIT_LIMIT=120
+
+# Authentication service RPC client
 AUTH_SERVICE_HOST=127.0.0.1
 AUTH_SERVICE_PORT=4010
+
+# JWT verification (must match the Auth service)
+JWT_ACCESS_SECRET=supersecretaccesstoken
+JWT_ACCESS_EXPIRES=15m
+JWT_SECRET=supersecretaccesstoken
+JWT_EXPIRES_IN=15m
+
+# Messaging queues
+RABBITMQ_URL=amqp://admin:admin@localhost:5672
+TASKS_RPC_QUEUE=tasks.rpc
+TASKS_EVENTS_QUEUE=tasks.events
+NOTIFICATIONS_EVENTS_QUEUE=notifications.events
+
+# Comma-separated list of allowed origins for REST and WebSocket traffic
+CORS_ORIGINS=http://localhost:3000,http://127.0.0.1:3000

--- a/apps/auth/.env.example
+++ b/apps/auth/.env.example
@@ -1,6 +1,23 @@
 # Authentication service environment variables
 NODE_ENV=development
+AUTH_SERVICE_PORT=4010
+PORT=4010
+
+# Database connection (required)
 DATABASE_URL=postgres://postgres:password@localhost:5432/challenge_db
-JWT_SECRET=supersecret
-JWT_EXPIRES_IN=15m
+
+# Password hashing
 BCRYPT_SALT_ROUNDS=10
+
+# Access token configuration
+JWT_ACCESS_SECRET=supersecretaccesstoken
+JWT_ACCESS_EXPIRES=15m
+
+# Refresh token configuration
+JWT_REFRESH_SECRET=supersecretrefreshtoken
+JWT_REFRESH_EXPIRES=7d
+JWT_REFRESH_TTL=7d
+
+# Legacy fallbacks used when specific secrets/expirations are not provided
+JWT_SECRET=supersecretaccesstoken
+JWT_EXPIRES_IN=15m

--- a/apps/notifications/.env.example
+++ b/apps/notifications/.env.example
@@ -1,3 +1,10 @@
 # Notifications service environment variables
 NODE_ENV=development
-PORT=3000
+
+# RabbitMQ configuration
+RABBITMQ_URL=amqp://admin:admin@localhost:5672
+RABBITMQ_QUEUE=notifications.events
+RABBITMQ_PREFETCH=10
+
+# Queue used to forward WebSocket events to the API gateway
+GATEWAY_EVENTS_QUEUE=gateway.events

--- a/apps/tasks/.env.example
+++ b/apps/tasks/.env.example
@@ -1,5 +1,10 @@
 # Tasks service environment variables
 NODE_ENV=development
-PORT=3003
-CORS_ORIGIN=http://localhost:3000
+
+# Database connection (required)
+DATABASE_URL=postgres://postgres:password@localhost:5432/challenge_db
+
+# RabbitMQ configuration
 RABBITMQ_URL=amqp://admin:admin@localhost:5672
+RABBITMQ_QUEUE=tasks.rpc
+RABBITMQ_PREFETCH=10

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,8 +1,11 @@
+# Optional URL used when rendering on the server (e.g., SSR or tests)
+SERVER_URL=http://localhost:3000
+
 # Optional title displayed in the browser tab
-VITE_APP_TITLE=
+VITE_APP_TITLE=Jungle Gaming
 
 # Base URL used for REST API requests (defaults to the window origin when empty)
-VITE_API_BASE_URL=
+VITE_API_BASE_URL=http://localhost:3001/api
 
 # Optional WebSocket server URL. Defaults to the window origin when empty.
-VITE_WS_URL=
+VITE_WS_URL=http://localhost:3001


### PR DESCRIPTION
## Summary
- refresh the API gateway environment example with full rate limiting, messaging, JWT, and CORS settings
- document all required variables for the auth, tasks, and notifications services
- expand the web app example to include server and client environment values with sensible defaults

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e3145b19ec832b9268db52897c7a62