### PR TITLE
Add coverage for auth registration flow

### DIFF
--- a/apps/auth/src/auth/auth.service.spec.ts
+++ b/apps/auth/src/auth/auth.service.spec.ts
@@ -1,0 +1,128 @@
+import { HttpStatus } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { ConfigService } from '@nestjs/config';
+import { Repository } from 'typeorm';
+import { AuthService } from './auth.service';
+import { User } from '../users/entities/user.entity';
+import { CreateUserDto } from '../users/dto/create-user.dto';
+import { RpcException } from '@nestjs/microservices';
+import * as bcrypt from 'bcrypt';
+
+type MockRepository = Partial<Record<keyof Repository<User>, jest.Mock>>;
+
+describe('AuthService', () => {
+  let service: AuthService;
+  let usersRepository: MockRepository;
+  let jwtService: jest.Mocked<JwtService>;
+  let configService: jest.Mocked<ConfigService>;
+
+  beforeEach(() => {
+    usersRepository = {
+      findOne: jest.fn(),
+      create: jest.fn(),
+      save: jest.fn(),
+      update: jest.fn(),
+    };
+
+    jwtService = {
+      signAsync: jest.fn(),
+    } as unknown as jest.Mocked<JwtService>;
+
+    const configValues: Record<string, unknown> = {
+      BCRYPT_SALT_ROUNDS: 1,
+      JWT_REFRESH_SECRET: 'refreshSecretKey',
+      JWT_REFRESH_EXPIRES: '7d',
+      JWT_ACCESS_SECRET: 'accessSecretKey',
+      JWT_ACCESS_EXPIRES: '15m',
+      JWT_SECRET: 'accessSecretKey',
+      JWT_EXPIRES_IN: '15m',
+    };
+
+    configService = {
+      get: jest.fn(<T = unknown>(key: string, defaultValue?: T) =>
+        (configValues[key] ?? defaultValue) as T,
+      ),
+    } as unknown as jest.Mocked<ConfigService>;
+
+    service = new AuthService(
+      usersRepository as unknown as Repository<User>,
+      jwtService,
+      configService,
+    );
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('registers a user hashing password, issuing tokens and persisting refresh token', async () => {
+    const dto: CreateUserDto = {
+      email: 'john@example.com',
+      name: 'John Doe',
+      password: 'strong-password',
+    };
+
+    (usersRepository.findOne as jest.Mock).mockResolvedValue(null);
+    (usersRepository.create as jest.Mock).mockImplementation((entity) => entity);
+    (usersRepository.save as jest.Mock).mockImplementation(async (entity) => ({
+      id: 'user-1',
+      email: entity.email,
+      name: entity.name,
+      passwordHash: entity.passwordHash,
+    }));
+
+    (usersRepository.update as jest.Mock).mockResolvedValue(undefined);
+
+    jwtService.signAsync
+      .mockResolvedValueOnce('refresh-token')
+      .mockResolvedValueOnce('access-token');
+
+    const result = await service.register(dto);
+
+    expect(usersRepository.findOne).toHaveBeenCalledWith({
+      where: { email: dto.email },
+    });
+    expect(usersRepository.create).toHaveBeenCalled();
+    const created = (usersRepository.create as jest.Mock).mock.calls[0][0];
+    await expect(
+      bcrypt.compare(dto.password, created.passwordHash),
+    ).resolves.toBe(true);
+    expect(usersRepository.save).toHaveBeenCalledWith(created);
+    expect(jwtService.signAsync).toHaveBeenCalledTimes(2);
+    expect(usersRepository.update).toHaveBeenCalled();
+    const refreshHash = (usersRepository.update as jest.Mock).mock.calls[0][1]
+      .refreshTokenHash as string;
+    await expect(bcrypt.compare('refresh-token', refreshHash)).resolves.toBe(true);
+    expect(result).toEqual({
+      user: { id: 'user-1', email: dto.email, name: dto.name },
+      accessToken: 'access-token',
+      refreshToken: 'refresh-token',
+    });
+  });
+
+  it('throws a conflict RpcException when email is already registered', async () => {
+    const dto: CreateUserDto = {
+      email: 'john@example.com',
+      name: 'John Doe',
+      password: 'strong-password',
+    };
+
+    (usersRepository.findOne as jest.Mock).mockResolvedValue({
+      id: 'existing',
+    });
+
+    try {
+      await service.register(dto);
+      fail('register should have thrown');
+    } catch (error) {
+      expect(error).toBeInstanceOf(RpcException);
+      expect((error as RpcException).getError()).toMatchObject({
+        statusCode: HttpStatus.CONFLICT,
+        message: 'Email address is already registered.',
+      });
+    }
+
+    expect(usersRepository.create).not.toHaveBeenCalled();
+    expect(jwtService.signAsync).not.toHaveBeenCalled();
+  });
+});

--- a/apps/auth/src/users/dto/create-user.dto.ts
+++ b/apps/auth/src/users/dto/create-user.dto.ts
@@ -1,4 +1,4 @@
-import { IsEmail, IsNotEmpty, IsString } from 'class-validator';
+import { IsEmail, IsNotEmpty, IsString, MinLength } from 'class-validator';
 import type { AuthRegisterRequest } from '@repo/types';
 
 export class CreateUserDto implements AuthRegisterRequest {
@@ -26,6 +26,9 @@ export class CreateUserDto implements AuthRegisterRequest {
   })
   @IsNotEmpty({
     message: 'password must not be empty',
+  })
+  @MinLength(6, {
+    message: 'password must be at least 6 characters long',
   })
   password!: string;
 }

--- a/apps/auth/test/app.e2e-spec.ts
+++ b/apps/auth/test/app.e2e-spec.ts
@@ -1,25 +1,139 @@
+import { Body, Controller, INestApplication, Post, ValidationPipe } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import { INestApplication } from '@nestjs/common';
-import * as request from 'supertest';
+import request from 'supertest';
 import { App } from 'supertest/types';
-import { AppModule } from './../src/app.module';
+import { AuthService } from '../src/auth/auth.service';
+import { CreateUserDto } from '../src/users/dto/create-user.dto';
+import { User } from '../src/users/entities/user.entity';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { JwtService } from '@nestjs/jwt';
+import { ConfigService } from '@nestjs/config';
+import * as bcrypt from 'bcrypt';
+import type { Repository } from 'typeorm';
+
+type StoredUser = Pick<User, 'id' | 'email' | 'name' | 'passwordHash'> & {
+  refreshTokenHash?: string | null;
+};
+
+@Controller('auth')
+class AuthHttpController {
+  constructor(private readonly authService: AuthService) {}
+
+  @Post('register')
+  register(@Body() dto: CreateUserDto) {
+    return this.authService.register(dto);
+  }
+}
+
+const users: StoredUser[] = [];
+let idCounter = 1;
+
+const usersRepository = {
+  findOne: jest.fn(async ({ where: { email } }: { where: { email: string } }) => {
+    return users.find((user) => user.email === email) ?? null;
+  }),
+  create: jest.fn((entity: Partial<User>) => entity),
+  save: jest.fn(async (entity: Partial<User>) => {
+    const user: StoredUser = {
+      id: `user-${idCounter++}`,
+      email: entity.email as string,
+      name: entity.name as string,
+      passwordHash: entity.passwordHash as string,
+    };
+    users.push(user);
+    return user as unknown as User;
+  }),
+  update: jest.fn(async ({ id }: { id: string }, partial: Partial<User>) => {
+    const index = users.findIndex((user) => user.id === id);
+    if (index !== -1) {
+      users[index] = {
+        ...users[index],
+        ...partial,
+      };
+    }
+  }),
+} as Partial<Record<keyof Repository<User>, jest.Mock>>;
+
+const configValues: Record<string, unknown> = {
+  BCRYPT_SALT_ROUNDS: 1,
+  JWT_REFRESH_SECRET: 'refresh-secret',
+  JWT_REFRESH_EXPIRES: '1d',
+  JWT_ACCESS_SECRET: 'access-secret',
+  JWT_ACCESS_EXPIRES: '15m',
+  JWT_SECRET: 'access-secret',
+  JWT_EXPIRES_IN: '15m',
+};
+
+const configService: Partial<ConfigService> = {
+  get: <T = unknown>(key: string, defaultValue?: T) =>
+    (configValues[key] ?? defaultValue) as T,
+};
+
+const jwtService = new JwtService({});
 
 describe('AppController (e2e)', () => {
   let app: INestApplication<App>;
 
   beforeEach(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [AppModule],
+      controllers: [AuthHttpController],
+      providers: [
+        AuthService,
+        {
+          provide: getRepositoryToken(User),
+          useValue: usersRepository as Partial<Repository<User>>,
+        },
+        { provide: JwtService, useValue: jwtService },
+        { provide: ConfigService, useValue: configService },
+      ],
     }).compile();
 
     app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(new ValidationPipe({ whitelist: true }));
     await app.init();
   });
 
-  it('/ (GET)', () => {
-    return request(app.getHttpServer())
-      .get('/')
-      .expect(200)
-      .expect('Hello World!');
+  afterEach(async () => {
+    await app.close();
+    users.length = 0;
+    idCounter = 1;
+    jest.clearAllMocks();
+  });
+
+  it('POST /auth/register should enforce validation rules', async () => {
+    const response = await request(app.getHttpServer())
+      .post('/auth/register')
+      .send({
+        email: 'john@example.com',
+        name: 'John Doe',
+        password: '12345',
+      });
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toContain('password must be at least 6 characters long');
+  });
+
+  it('POST /auth/register should hash password and store hashed refresh token', async () => {
+    const response = await request(app.getHttpServer())
+      .post('/auth/register')
+      .send({
+        email: 'john@example.com',
+        name: 'John Doe',
+        password: 'strong-password',
+      })
+      .expect(201);
+
+    expect(response.body).toHaveProperty('accessToken');
+    expect(response.body).toHaveProperty('refreshToken');
+    expect(users).toHaveLength(1);
+
+    const stored = users[0];
+
+    expect(stored.passwordHash).not.toBe('strong-password');
+    await expect(bcrypt.compare('strong-password', stored.passwordHash)).resolves.toBe(true);
+    expect(stored.refreshTokenHash).toBeDefined();
+    await expect(
+      bcrypt.compare(response.body.refreshToken, stored.refreshTokenHash ?? ''),
+    ).resolves.toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- enforce a minimum password length in the CreateUserDto
- add unit tests for AuthService.register covering success and email conflicts
- extend the auth e2e suite to exercise POST /auth/register with validation and hashing checks

## Testing
- pnpm --filter @apps/auth-service test
- pnpm --filter @apps/auth-service test:e2e

------
https://chatgpt.com/codex/tasks/task_e_68e56e90a358832b8a903474d05a0bf9