### PR TITLE
refactor: centralize database bootstrap helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ dist/
 coverage/
 
 *.tsbuildinfo
+
+dist-cjs/
+v8-compile-cache-*/

--- a/apps/auth/package.json
+++ b/apps/auth/package.json
@@ -81,12 +81,20 @@
     "rootDir": "src",
     "testRegex": ".*\\.spec\\.ts$",
     "transform": {
-      "^.+\\.(t|j)s$": "ts-jest"
+      "^.+\\.ts$": "ts-jest"
     },
     "collectCoverageFrom": [
       "**/*.(t|j)s"
     ],
     "coverageDirectory": "../coverage",
-    "testEnvironment": "node"
+    "testEnvironment": "node",
+    "extensionsToTreatAsEsm": [
+      ".ts"
+    ],
+    "moduleNameMapper": {
+      "^(\\.{1,2}/.*)\\.js$": "$1",
+      "^@repo/types$": "<rootDir>/../../../packages/types/dist-cjs/index.js",
+      "^@repo/types/(.*)$": "<rootDir>/../../../packages/types/dist-cjs/$1.js"
+    }
   }
 }

--- a/apps/auth/src/database/wait-for-database.ts
+++ b/apps/auth/src/database/wait-for-database.ts
@@ -1,82 +1,27 @@
 import { Logger } from '@nestjs/common';
-import { Client } from 'pg';
-
-const DEFAULT_INITIAL_DELAY_MS = 500;
-const DEFAULT_MAX_DELAY_MS = 5000;
-const DEFAULT_MAX_ATTEMPTS = 10;
-const DEFAULT_CONNECTION_TIMEOUT_MS = 3000;
+import {
+  resolveWaitForDatabaseOptions as sharedResolveWaitForDatabaseOptions,
+  waitForDatabase as sharedWaitForDatabase,
+  type ResolvedWaitForDatabaseOptions as SharedResolvedWaitForDatabaseOptions,
+  type WaitForDatabaseOptions as SharedWaitForDatabaseOptions,
+} from '@repo/types/utils/database';
 
 const logger = new Logger('DatabaseBootstrap');
 
-const parsePositiveInt = (value: string | undefined, fallback: number): number => {
-  if (!value) {
-    return fallback;
-  }
+export type WaitForDatabaseOptions = SharedWaitForDatabaseOptions;
+export type ResolvedWaitForDatabaseOptions = SharedResolvedWaitForDatabaseOptions;
 
-  const parsed = Number.parseInt(value, 10);
-
-  if (!Number.isFinite(parsed) || parsed <= 0) {
-    return fallback;
-  }
-
-  return parsed;
+export const waitForDatabase = async (
+  options: SharedWaitForDatabaseOptions,
+): Promise<void> => {
+  await sharedWaitForDatabase({
+    ...options,
+    logger,
+  });
 };
 
-const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
-
-export interface WaitForDatabaseOptions {
-  connectionString: string;
-  initialDelayMs?: number;
-  maxDelayMs?: number;
-  maxAttempts?: number;
-  connectionTimeoutMs?: number;
-}
-
-export const waitForDatabase = async ({
-  connectionString,
-  initialDelayMs = DEFAULT_INITIAL_DELAY_MS,
-  maxDelayMs = DEFAULT_MAX_DELAY_MS,
-  maxAttempts = DEFAULT_MAX_ATTEMPTS,
-  connectionTimeoutMs = DEFAULT_CONNECTION_TIMEOUT_MS,
-}: WaitForDatabaseOptions): Promise<void> => {
-  let attempt = 0;
-  let delayMs = initialDelayMs;
-
-  while (attempt < maxAttempts) {
-    attempt += 1;
-
-    try {
-      const client = new Client({
-        connectionString,
-        connectionTimeoutMillis: connectionTimeoutMs,
-      });
-
-      await client.connect();
-      await client.end();
-
-      logger.log(`Successfully connected to PostgreSQL on attempt ${attempt}.`);
-      return;
-    } catch (error) {
-      if (attempt >= maxAttempts) {
-        logger.error('Exhausted all attempts to reach PostgreSQL.', error as Error);
-        throw error;
-      }
-
-      const errorMessage = error instanceof Error ? error.message : String(error);
-      logger.warn(
-        `Attempt ${attempt} to connect to PostgreSQL failed (${errorMessage}). Retrying in ${delayMs}ms...`,
-      );
-
-      await delay(delayMs);
-      delayMs = Math.min(delayMs * 2, maxDelayMs);
-    }
-  }
-};
-
-export const resolveWaitForDatabaseOptions = (env: NodeJS.ProcessEnv, connectionString: string): WaitForDatabaseOptions => ({
-  connectionString,
-  initialDelayMs: parsePositiveInt(env.DATABASE_BOOTSTRAP_INITIAL_DELAY_MS, DEFAULT_INITIAL_DELAY_MS),
-  maxDelayMs: parsePositiveInt(env.DATABASE_BOOTSTRAP_MAX_DELAY_MS, DEFAULT_MAX_DELAY_MS),
-  maxAttempts: parsePositiveInt(env.DATABASE_BOOTSTRAP_MAX_ATTEMPTS, DEFAULT_MAX_ATTEMPTS),
-  connectionTimeoutMs: parsePositiveInt(env.DATABASE_BOOTSTRAP_CONNECTION_TIMEOUT_MS, DEFAULT_CONNECTION_TIMEOUT_MS),
-});
+export const resolveWaitForDatabaseOptions = (
+  env: NodeJS.ProcessEnv,
+  connectionString: string,
+): SharedResolvedWaitForDatabaseOptions =>
+  sharedResolveWaitForDatabaseOptions(env, connectionString);

--- a/apps/tasks/package.json
+++ b/apps/tasks/package.json
@@ -77,12 +77,20 @@
     "rootDir": "src",
     "testRegex": ".*\\.spec\\.ts$",
     "transform": {
-      "^.+\\.(t|j)s$": "ts-jest"
+      "^.+\\.ts$": "ts-jest"
     },
     "collectCoverageFrom": [
       "**/*.(t|j)s"
     ],
     "coverageDirectory": "../coverage",
-    "testEnvironment": "node"
+    "testEnvironment": "node",
+    "extensionsToTreatAsEsm": [
+      ".ts"
+    ],
+    "moduleNameMapper": {
+      "^(\\.{1,2}/.*)\\.js$": "$1",
+      "^@repo/types$": "<rootDir>/../../../packages/types/dist-cjs/index.js",
+      "^@repo/types/(.*)$": "<rootDir>/../../../packages/types/dist-cjs/$1.js"
+    }
   }
 }

--- a/apps/tasks/src/database/wait-for-database.ts
+++ b/apps/tasks/src/database/wait-for-database.ts
@@ -1,124 +1,27 @@
 import { Logger } from '@nestjs/common';
-import { Client } from 'pg';
-import type { ClientConfig } from 'pg';
-
-const DEFAULT_INITIAL_DELAY_MS = 500;
-const DEFAULT_MAX_DELAY_MS = 5000;
-const DEFAULT_MAX_ATTEMPTS = 10;
-const DEFAULT_CONNECTION_TIMEOUT_MS = 3000;
+import {
+  resolveWaitForDatabaseOptions as sharedResolveWaitForDatabaseOptions,
+  waitForDatabase as sharedWaitForDatabase,
+  type ResolvedWaitForDatabaseOptions as SharedResolvedWaitForDatabaseOptions,
+  type WaitForDatabaseOptions as SharedWaitForDatabaseOptions,
+} from '@repo/types/utils/database';
 
 const logger = new Logger('TasksDatabaseBootstrap');
 
-interface PgClient {
-  connect(): Promise<void>;
-  end(): Promise<void>;
-}
+export type WaitForDatabaseOptions = SharedWaitForDatabaseOptions;
+export type ResolvedWaitForDatabaseOptions = SharedResolvedWaitForDatabaseOptions;
 
-type PgClientConstructor = new (config: ClientConfig) => PgClient;
-
-const isPgClientConstructor = (value: unknown): value is PgClientConstructor =>
-  typeof value === 'function';
-
-const parsePositiveInt = (
-  value: string | undefined,
-  fallback: number,
-): number => {
-  if (!value) {
-    return fallback;
-  }
-
-  const parsed = Number.parseInt(value, 10);
-
-  if (!Number.isFinite(parsed) || parsed <= 0) {
-    return fallback;
-  }
-
-  return parsed;
-};
-
-const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
-
-export interface WaitForDatabaseOptions {
-  connectionString: string;
-  initialDelayMs?: number;
-  maxDelayMs?: number;
-  maxAttempts?: number;
-  connectionTimeoutMs?: number;
-}
-
-export const waitForDatabase = async ({
-  connectionString,
-  initialDelayMs = DEFAULT_INITIAL_DELAY_MS,
-  maxDelayMs = DEFAULT_MAX_DELAY_MS,
-  maxAttempts = DEFAULT_MAX_ATTEMPTS,
-  connectionTimeoutMs = DEFAULT_CONNECTION_TIMEOUT_MS,
-}: WaitForDatabaseOptions): Promise<void> => {
-  let attempt = 0;
-  let delayMs = initialDelayMs;
-
-  while (attempt < maxAttempts) {
-    attempt += 1;
-
-    try {
-      const clientCtor: unknown = Client;
-
-      if (!isPgClientConstructor(clientCtor)) {
-        throw new TypeError('Invalid PostgreSQL client constructor.');
-      }
-
-      const client = new clientCtor({
-        connectionString,
-        connectionTimeoutMillis: connectionTimeoutMs,
-      });
-
-      await client.connect();
-      await client.end();
-
-      logger.log(`Successfully connected to PostgreSQL on attempt ${attempt}.`);
-      return;
-    } catch (error: unknown) {
-      if (attempt >= maxAttempts) {
-        logger.error(
-          'Exhausted all attempts to reach PostgreSQL.',
-          error as Error,
-        );
-        throw error;
-      }
-
-      const message = error instanceof Error ? error.message : String(error);
-      logger.warn(
-        `Attempt ${attempt} to connect to PostgreSQL failed (${message}). Retrying in ${delayMs}ms...`,
-      );
-
-      await delay(delayMs);
-      delayMs = Math.min(delayMs * 2, maxDelayMs);
-    }
-  }
+export const waitForDatabase = async (
+  options: SharedWaitForDatabaseOptions,
+): Promise<void> => {
+  await sharedWaitForDatabase({
+    ...options,
+    logger,
+  });
 };
 
 export const resolveWaitForDatabaseOptions = (
   env: NodeJS.ProcessEnv,
   connectionString: string,
-): WaitForDatabaseOptions => ({
-  connectionString,
-  initialDelayMs: parsePositiveInt(
-    env.TASKS_DATABASE_BOOTSTRAP_INITIAL_DELAY_MS ??
-      env.DATABASE_BOOTSTRAP_INITIAL_DELAY_MS,
-    DEFAULT_INITIAL_DELAY_MS,
-  ),
-  maxDelayMs: parsePositiveInt(
-    env.TASKS_DATABASE_BOOTSTRAP_MAX_DELAY_MS ??
-      env.DATABASE_BOOTSTRAP_MAX_DELAY_MS,
-    DEFAULT_MAX_DELAY_MS,
-  ),
-  maxAttempts: parsePositiveInt(
-    env.TASKS_DATABASE_BOOTSTRAP_MAX_ATTEMPTS ??
-      env.DATABASE_BOOTSTRAP_MAX_ATTEMPTS,
-    DEFAULT_MAX_ATTEMPTS,
-  ),
-  connectionTimeoutMs: parsePositiveInt(
-    env.TASKS_DATABASE_BOOTSTRAP_CONNECTION_TIMEOUT_MS ??
-      env.DATABASE_BOOTSTRAP_CONNECTION_TIMEOUT_MS,
-    DEFAULT_CONNECTION_TIMEOUT_MS,
-  ),
-});
+): SharedResolvedWaitForDatabaseOptions =>
+  sharedResolveWaitForDatabaseOptions(env, connectionString, 'TASKS_');

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -8,19 +8,24 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist-cjs/index.js",
       "default": "./dist/index.js"
     },
     "./*": {
       "types": "./dist/*.d.ts",
+      "import": "./dist/*.js",
+      "require": "./dist-cjs/*.js",
       "default": "./dist/*.js"
     }
   },
   "files": [
     "dist",
+    "dist-cjs",
     "src"
   ],
   "scripts": {
-    "build": "tsc -p tsconfig.json",
+    "build": "tsc -p tsconfig.json && tsc -p tsconfig.cjs.json",
     "lint": "eslint . --ext .ts --max-warnings 0",
     "check-types": "tsc --noEmit",
     "prepare": "pnpm run build"
@@ -28,12 +33,14 @@
   "dependencies": {
     "@nestjs/swagger": "^11.2.0",
     "class-transformer": "^0.5.1",
-    "class-validator": "^0.14.2"
+    "class-validator": "^0.14.2",
+    "pg": "^8.16.3"
   },
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",
     "@repo/typescript-config": "workspace:*",
     "@types/node": "^22.15.3",
+    "@types/pg": "^8.11.10",
     "eslint": "^9.34.0",
     "typescript": "5.9.2"
   }

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./dto/index.js";
 export * from "./enums/index.js";
 export * from "./contracts/index.js";
+export * from "./utils/index.js";

--- a/packages/types/src/utils/database.ts
+++ b/packages/types/src/utils/database.ts
@@ -1,0 +1,165 @@
+import { Client } from "pg";
+import type { ClientConfig } from "pg";
+
+const DEFAULT_INITIAL_DELAY_MS = 500;
+const DEFAULT_MAX_DELAY_MS = 5_000;
+const DEFAULT_MAX_ATTEMPTS = 10;
+const DEFAULT_CONNECTION_TIMEOUT_MS = 3_000;
+
+export interface LoggerLike {
+  log(message: string): void;
+  warn(message: string): void;
+  error(message: string, error?: unknown): void;
+}
+
+export interface WaitForDatabaseOptions {
+  connectionString: string;
+  initialDelayMs?: number;
+  maxDelayMs?: number;
+  maxAttempts?: number;
+  connectionTimeoutMs?: number;
+  logger?: LoggerLike;
+}
+
+export type ResolvedWaitForDatabaseOptions = Omit<
+  WaitForDatabaseOptions,
+  "logger"
+>;
+
+const isPgClientConstructor = (value: unknown): value is new (
+  config: ClientConfig,
+) => { connect(): Promise<void>; end(): Promise<void> } =>
+  typeof value === "function";
+
+const defaultLogger: LoggerLike = {
+  log: (message) => console.log(message),
+  warn: (message) => console.warn(message),
+  error: (message, error) => {
+    if (error !== undefined) {
+      console.error(message, error);
+      return;
+    }
+
+    console.error(message);
+  },
+};
+
+export const parsePositiveInt = (
+  value: string | undefined,
+  fallback: number,
+): number => {
+  if (!value) {
+    return fallback;
+  }
+
+  const parsed = Number.parseInt(value, 10);
+
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return fallback;
+  }
+
+  return parsed;
+};
+
+export const delay = (ms: number) =>
+  new Promise<void>((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+export const waitForDatabase = async ({
+  connectionString,
+  initialDelayMs = DEFAULT_INITIAL_DELAY_MS,
+  maxDelayMs = DEFAULT_MAX_DELAY_MS,
+  maxAttempts = DEFAULT_MAX_ATTEMPTS,
+  connectionTimeoutMs = DEFAULT_CONNECTION_TIMEOUT_MS,
+  logger = defaultLogger,
+}: WaitForDatabaseOptions): Promise<void> => {
+  let attempt = 0;
+  let delayMs = initialDelayMs;
+
+  while (attempt < maxAttempts) {
+    attempt += 1;
+
+    try {
+      const clientCtor: unknown = Client;
+
+      if (!isPgClientConstructor(clientCtor)) {
+        throw new TypeError("Invalid PostgreSQL client constructor.");
+      }
+
+      const client = new clientCtor({
+        connectionString,
+        connectionTimeoutMillis: connectionTimeoutMs,
+      });
+
+      await client.connect();
+      await client.end();
+
+      logger.log(`Successfully connected to PostgreSQL on attempt ${attempt}.`);
+      return;
+    } catch (error) {
+      if (attempt >= maxAttempts) {
+        logger.error("Exhausted all attempts to reach PostgreSQL.", error);
+        throw error;
+      }
+
+      const message = error instanceof Error ? error.message : String(error);
+      logger.warn(
+        `Attempt ${attempt} to connect to PostgreSQL failed (${message}). Retrying in ${delayMs}ms...`,
+      );
+
+      await delay(delayMs);
+      delayMs = Math.min(delayMs * 2, maxDelayMs);
+    }
+  }
+};
+
+const getBootstrapEnvValue = (
+  env: NodeJS.ProcessEnv,
+  suffix: string,
+  prefix?: string,
+) => {
+  const prefixedKey = prefix ? `${prefix}${suffix}` : undefined;
+  const prefixedValue = prefixedKey ? env[prefixedKey] : undefined;
+
+  return prefixedValue ?? env[suffix];
+};
+
+export const resolveWaitForDatabaseOptions = (
+  env: NodeJS.ProcessEnv,
+  connectionString: string,
+  prefix?: string,
+): ResolvedWaitForDatabaseOptions => ({
+  connectionString,
+  initialDelayMs: parsePositiveInt(
+    getBootstrapEnvValue(
+      env,
+      "DATABASE_BOOTSTRAP_INITIAL_DELAY_MS",
+      prefix,
+    ),
+    DEFAULT_INITIAL_DELAY_MS,
+  ),
+  maxDelayMs: parsePositiveInt(
+    getBootstrapEnvValue(env, "DATABASE_BOOTSTRAP_MAX_DELAY_MS", prefix),
+    DEFAULT_MAX_DELAY_MS,
+  ),
+  maxAttempts: parsePositiveInt(
+    getBootstrapEnvValue(env, "DATABASE_BOOTSTRAP_MAX_ATTEMPTS", prefix),
+    DEFAULT_MAX_ATTEMPTS,
+  ),
+  connectionTimeoutMs: parsePositiveInt(
+    getBootstrapEnvValue(
+      env,
+      "DATABASE_BOOTSTRAP_CONNECTION_TIMEOUT_MS",
+      prefix,
+    ),
+    DEFAULT_CONNECTION_TIMEOUT_MS,
+  ),
+});
+
+export const __TESTING__ = {
+  DEFAULT_INITIAL_DELAY_MS,
+  DEFAULT_MAX_DELAY_MS,
+  DEFAULT_MAX_ATTEMPTS,
+  DEFAULT_CONNECTION_TIMEOUT_MS,
+};

--- a/packages/types/src/utils/index.ts
+++ b/packages/types/src/utils/index.ts
@@ -1,0 +1,1 @@
+export * from "./database.js";

--- a/packages/types/tsconfig.cjs.json
+++ b/packages/types/tsconfig.cjs.json
@@ -1,0 +1,23 @@
+{
+  "extends": "@repo/typescript-config/base.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "rootDir": "src",
+    "outDir": "dist-cjs",
+    "declaration": true,
+    "declarationMap": false,
+    "incremental": false,
+    "composite": false,
+    "emitDeclarationOnly": false,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "esModuleInterop": true,
+    "isolatedModules": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "target": "ES2022"
+  },
+  "include": ["src/**/*.ts", "src/**/*.d.ts"],
+  "exclude": ["dist", "dist-cjs", "node_modules"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -748,6 +748,9 @@ importers:
       class-validator:
         specifier: ^0.14.2
         version: 0.14.2
+      pg:
+        specifier: ^8.16.3
+        version: 8.16.3
     devDependencies:
       '@repo/eslint-config':
         specifier: workspace:*
@@ -758,6 +761,9 @@ importers:
       '@types/node':
         specifier: ^22.15.3
         version: 22.15.3
+      '@types/pg':
+        specifier: ^8.11.10
+        version: 8.15.5
       eslint:
         specifier: ^9.34.0
         version: 9.34.0(jiti@2.6.1)


### PR DESCRIPTION
## Summary
- add shared wait-for-database utilities to @repo/types with reusable delay and env parsing helpers
- update the auth and tasks database bootstrap code to delegate to the shared implementation and configure Jest to resolve it
- extend the types package build to emit a CommonJS bundle for tests and adjust ignores for generated artifacts

## Testing
- pnpm --filter @apps/tasks-service test
- pnpm --filter @apps/auth-service test

------
https://chatgpt.com/codex/tasks/task_e_68e5830c9630832bae025a9e4e4c10cb