### PR TITLE
feat: enforce shared types boundaries

### DIFF
--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -14,6 +14,10 @@
     "sourceMap": true,
     "outDir": "./dist",
     "baseUrl": "./",
+    "paths": {
+      "@repo/types": ["../../packages/types/src/index.ts"],
+      "@repo/types/*": ["../../packages/types/src/*"]
+    },
     "incremental": true,
     "skipLibCheck": true,
     "strictNullChecks": true,

--- a/apps/auth/tsconfig.json
+++ b/apps/auth/tsconfig.json
@@ -14,6 +14,10 @@
     "sourceMap": true,
     "outDir": "./dist",
     "baseUrl": "./",
+    "paths": {
+      "@repo/types": ["../../packages/types/src/index.ts"],
+      "@repo/types/*": ["../../packages/types/src/*"]
+    },
     "incremental": true,
     "skipLibCheck": true,
     "strictNullChecks": true,

--- a/apps/notifications/tsconfig.json
+++ b/apps/notifications/tsconfig.json
@@ -14,6 +14,10 @@
     "sourceMap": true,
     "outDir": "./dist",
     "baseUrl": "./",
+    "paths": {
+      "@repo/types": ["../../packages/types/src/index.ts"],
+      "@repo/types/*": ["../../packages/types/src/*"]
+    },
     "incremental": true,
     "skipLibCheck": true,
     "strictNullChecks": true,

--- a/apps/tasks/tsconfig.json
+++ b/apps/tasks/tsconfig.json
@@ -14,6 +14,10 @@
     "sourceMap": true,
     "outDir": "./dist",
     "baseUrl": "./",
+    "paths": {
+      "@repo/types": ["../../packages/types/src/index.ts"],
+      "@repo/types/*": ["../../packages/types/src/*"]
+    },
     "incremental": true,
     "skipLibCheck": true,
     "strictNullChecks": true,

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -33,11 +33,11 @@
         "./src/*"
       ],
       "@repo/types": [
-        "../../packages/types/src"
+        "../../packages/types/src/index.ts"
       ],
       "@repo/types/*": [
         "../../packages/types/src/*"
-      ],
+      ]
     }
   }
 }

--- a/docs/CONTRATOS_COMPARTILHADOS.md
+++ b/docs/CONTRATOS_COMPARTILHADOS.md
@@ -1,0 +1,26 @@
+# Fluxo para contratos compartilhados
+
+Este guia explica como criar e manter contratos (DTOs, interfaces e tipos utilitários) compartilhados no monorepositório.
+
+## Estrutura oficial
+
+Todos os contratos vivem em [`packages/types`](../packages/types). O ponto de entrada exporta automaticamente os módulos presentes em `src/contracts`, `src/dto`, `src/enums` e `src/utils`. Ao criar um novo contrato, mantenha a estrutura existente e lembre-se de atualizar os `index.ts` relevantes para expor o artefato pelo pacote `@repo/types`.
+
+## Criação ou atualização de contratos
+
+1. **Escolha o local correto** – novos DTOs ou interfaces devem ficar dentro de `packages/types/src`, seguindo o agrupamento atual (`dto`, `contracts`, `enums`, `utils`).
+2. **Implemente o contrato** – crie ou edite o arquivo TypeScript necessário.
+3. **Atualize os agregadores** – exporte o novo contrato no `index.ts` da pasta e, se necessário, no `src/index.ts`.
+4. **Valide localmente** – execute `pnpm lint` e `pnpm check-types` a partir da raiz para garantir que os contratos estejam corretos e que os consumidores continuem compilando.
+5. **Atualize consumidores** – importe o contrato usando o alias `@repo/types` (por exemplo, `import { UserDTO } from "@repo/types";`).
+
+> ⚠️ O ESLint está configurado para alertar sempre que interfaces/DTOs forem declarados fora de `packages/types` ou quando um import relativo for utilizado para consumir contratos compartilhados. Corrija o código movendo a declaração para `packages/types` e importando via `@repo/types`.
+
+## Processo de revisão
+
+1. Abra um Pull Request descrevendo as mudanças de contrato e os impactos esperados nas aplicações.
+2. Marque as squads impactadas e solicite revisão de pelo menos um mantenedor de `packages/types`.
+3. Garanta que os contratos possuam versionamento semântico na documentação ou changelog relevante, quando aplicável.
+4. Antes do merge, confirme novamente que `pnpm lint` e `pnpm check-types` passam com sucesso no CI.
+
+Seguir este fluxo garante que todos os serviços utilizem contratos unificados e evita divergências entre implementações.

--- a/packages/eslint-config/base.js
+++ b/packages/eslint-config/base.js
@@ -22,6 +22,48 @@ export const config = [
     },
   },
   {
+    files: ["**/*.{ts,tsx}"],
+    ignores: ["packages/types/**/*"],
+    rules: {
+      "no-restricted-syntax": [
+        "warn",
+        {
+          selector: "TSInterfaceDeclaration[id.name=/DTO$/i]",
+          message:
+            "Shared DTO interfaces must be declared in packages/types and imported via @repo/types.",
+        },
+        {
+          selector: "TSTypeAliasDeclaration[id.name=/DTO$/]",
+          message:
+            "DTO type aliases must live in packages/types and be imported via @repo/types.",
+        },
+      ],
+      "no-restricted-imports": [
+        "warn",
+        {
+          patterns: [
+            {
+              group: [
+                "../**/types",
+                "../**/types/*",
+                "**/packages/types",
+                "**/packages/types/*",
+              ],
+              message: "Import shared contracts from @repo/types instead of using relative paths.",
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
+    files: ["packages/types/**/*"],
+    rules: {
+      "no-restricted-syntax": "off",
+      "no-restricted-imports": "off",
+    },
+  },
+  {
     plugins: {
       onlyWarn,
     },

--- a/packages/types/eslint.config.mjs
+++ b/packages/types/eslint.config.mjs
@@ -1,3 +1,11 @@
 import { config } from "@repo/eslint-config/base";
 
-export default config;
+export default [
+  ...config,
+  {
+    rules: {
+      "no-restricted-syntax": "off",
+      "no-restricted-imports": "off",
+    },
+  },
+];

--- a/packages/typescript-config/base.json
+++ b/packages/typescript-config/base.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "compilerOptions": {
+    "baseUrl": "./",
     "declaration": true,
     "declarationMap": true,
     "esModuleInterop": true,
@@ -14,6 +15,10 @@
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "strict": true,
+    "paths": {
+      "@repo/types": ["../types/src/index.ts"],
+      "@repo/types/*": ["../types/src/*"]
+    },
     "target": "ES2022"
   }
 }


### PR DESCRIPTION
## Summary
- add repository-wide ESLint guardrails for DTO declarations and imports while exempting the shared types package
- standardize the `@repo/types` path alias across the base TypeScript config and all application tsconfigs
- document the contract authoring and review process for shared types

## Testing
- pnpm lint *(fails: existing @typescript-eslint issues in apps/auth)*
- pnpm check-types *(fails: missing type declarations for optional dependencies in @repo/types)*

------
https://chatgpt.com/codex/tasks/task_e_68e591d59d9c832ba06c2418e7f9d1cb