### PR TITLE
fix: restore dist/main outputs for Nest services

### DIFF
--- a/apps/api/tsconfig.build.json
+++ b/apps/api/tsconfig.build.json
@@ -1,4 +1,10 @@
 {
   "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "paths": {
+      "@repo/types": ["../../packages/types/dist/index.d.ts"],
+      "@repo/types/*": ["../../packages/types/dist/*.d.ts"]
+    }
+  },
   "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]
 }

--- a/apps/auth/tsconfig.build.json
+++ b/apps/auth/tsconfig.build.json
@@ -1,4 +1,10 @@
 {
   "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "paths": {
+      "@repo/types": ["../../packages/types/dist/index.d.ts"],
+      "@repo/types/*": ["../../packages/types/dist/*.d.ts"]
+    }
+  },
   "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]
 }

--- a/apps/notifications/tsconfig.build.json
+++ b/apps/notifications/tsconfig.build.json
@@ -1,4 +1,10 @@
 {
   "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "paths": {
+      "@repo/types": ["../../packages/types/dist/index.d.ts"],
+      "@repo/types/*": ["../../packages/types/dist/*.d.ts"]
+    }
+  },
   "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]
 }

--- a/apps/tasks/tsconfig.build.json
+++ b/apps/tasks/tsconfig.build.json
@@ -1,4 +1,10 @@
 {
   "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "paths": {
+      "@repo/types": ["../../packages/types/dist/index.d.ts"],
+      "@repo/types/*": ["../../packages/types/dist/*.d.ts"]
+    }
+  },
   "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]
 }

--- a/turbo.json
+++ b/turbo.json
@@ -15,6 +15,7 @@
       "dependsOn": ["^check-types"]
     },
     "dev": {
+      "dependsOn": ["^build"],
       "cache": false,
       "persistent": true
     }


### PR DESCRIPTION
## Summary
- point each Nest service build config at the compiled @repo/types declarations so the TypeScript emit stays inside dist/
- require Turbo dev tasks to build their dependencies first so the shared types are available before watch mode starts

## Testing
- pnpm --filter @repo/types build
- pnpm --filter @apps/api-gateway build
- pnpm --filter @apps/auth-service build

------
https://chatgpt.com/codex/tasks/task_e_68e5a38b9938832bbab5f97d1757f65f