### PR TITLE
fix: stabilize types package cjs entrypoint

### DIFF
--- a/apps/api/tsconfig.build.json
+++ b/apps/api/tsconfig.build.json
@@ -1,4 +1,10 @@
 {
   "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "paths": {
+      "@repo/types": ["../../packages/types/dist/index.d.ts"],
+      "@repo/types/*": ["../../packages/types/dist/*.d.ts"]
+    }
+  },
   "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]
 }

--- a/apps/auth/tsconfig.build.json
+++ b/apps/auth/tsconfig.build.json
@@ -1,4 +1,10 @@
 {
   "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "paths": {
+      "@repo/types": ["../../packages/types/dist/index.d.ts"],
+      "@repo/types/*": ["../../packages/types/dist/*.d.ts"]
+    }
+  },
   "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]
 }

--- a/apps/notifications/tsconfig.build.json
+++ b/apps/notifications/tsconfig.build.json
@@ -1,4 +1,10 @@
 {
   "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "paths": {
+      "@repo/types": ["../../packages/types/dist/index.d.ts"],
+      "@repo/types/*": ["../../packages/types/dist/*.d.ts"]
+    }
+  },
   "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]
 }

--- a/apps/tasks/tsconfig.build.json
+++ b/apps/tasks/tsconfig.build.json
@@ -1,4 +1,10 @@
 {
   "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "paths": {
+      "@repo/types": ["../../packages/types/dist/index.d.ts"],
+      "@repo/types/*": ["../../packages/types/dist/*.d.ts"]
+    }
+  },
   "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -25,7 +25,9 @@
     "src"
   ],
   "scripts": {
-    "build": "tsc -p tsconfig.json && tsc -p tsconfig.cjs.json",
+    "build": "pnpm run build:esm && pnpm run build:cjs",
+    "build:esm": "tsc -p tsconfig.json",
+    "build:cjs": "tsc -p tsconfig.cjs.json && node ./scripts/ensure-cjs-package.cjs",
     "lint": "eslint . --ext .ts --max-warnings 0",
     "check-types": "tsc --noEmit",
     "prepare": "pnpm run build"

--- a/packages/types/scripts/ensure-cjs-package.cjs
+++ b/packages/types/scripts/ensure-cjs-package.cjs
@@ -1,0 +1,13 @@
+const { mkdirSync, writeFileSync } = require('fs');
+const { join } = require('path');
+
+const outputDir = join(__dirname, '..', 'dist-cjs');
+const packageJsonPath = join(outputDir, 'package.json');
+
+mkdirSync(outputDir, { recursive: true });
+
+const packageJson = {
+  type: 'commonjs',
+};
+
+writeFileSync(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`);

--- a/turbo.json
+++ b/turbo.json
@@ -15,6 +15,7 @@
       "dependsOn": ["^check-types"]
     },
     "dev": {
+      "dependsOn": ["^build"],
       "cache": false,
       "persistent": true
     }


### PR DESCRIPTION
## Summary
- split the @repo/types build into esm and cjs steps and add a post-step that drops a package.json into dist-cjs so Node treats the output as CommonJS
- keep the existing workspace exports while ensuring the generated cjs bundle can be required by Nest services in dev/watch mode

## Testing
- pnpm --filter @repo/types build
- pnpm --filter @apps/api-gateway exec nest start --watch --preserveWatchOutput

------
https://chatgpt.com/codex/tasks/task_e_68e5a38b9938832bbab5f97d1757f65f