### PR TITLE
Fix runtime exports in @repo/types and align service tsconfig paths

### DIFF
--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -15,8 +15,14 @@
     "outDir": "./dist",
     "baseUrl": "./",
     "paths": {
-      "@repo/types": ["../../packages/types/src/index.ts"],
-      "@repo/types/*": ["../../packages/types/src/*"]
+      "@repo/types": [
+        "../../packages/types/dist-cjs/index.js",
+        "../../packages/types/dist/index.d.ts"
+      ],
+      "@repo/types/*": [
+        "../../packages/types/dist-cjs/*.js",
+        "../../packages/types/dist/*.d.ts"
+      ]
     },
     "incremental": true,
     "skipLibCheck": true,

--- a/apps/auth/src/types-contracts.spec.ts
+++ b/apps/auth/src/types-contracts.spec.ts
@@ -1,0 +1,44 @@
+import {
+  AUTH_MESSAGE_PATTERNS,
+  TASKS_MESSAGE_PATTERNS,
+  TASK_EVENT_PATTERNS,
+  TASK_FORWARDING_PATTERNS,
+  TASKS_RPC_CLIENT,
+  TASKS_EVENTS_CLIENT,
+  NOTIFICATIONS_GATEWAY_CLIENT,
+} from "@repo/types";
+
+describe("@repo/types runtime contract", () => {
+  it("exposes auth message patterns", () => {
+    expect(AUTH_MESSAGE_PATTERNS).toEqual(
+      expect.objectContaining({
+        REGISTER: "auth.register",
+        LOGIN: "auth.login",
+        REFRESH: "auth.refresh",
+        LOGOUT: "auth.logout",
+        PING: "auth.ping",
+      }),
+    );
+  });
+
+  it("exposes task message and event patterns", () => {
+    expect(TASKS_MESSAGE_PATTERNS).toEqual(
+      expect.objectContaining({
+        CREATE: "tasks.create",
+        FIND_ALL: "tasks.findAll",
+        FIND_BY_ID: "tasks.findById",
+        UPDATE: "tasks.update",
+        REMOVE: "tasks.remove",
+      }),
+    );
+
+    expect(TASK_EVENT_PATTERNS.CREATED).toBe("task.created");
+    expect(TASK_FORWARDING_PATTERNS.UPDATED).toBe("tasks.updated");
+  });
+
+  it("exposes microservice client tokens", () => {
+    expect(TASKS_RPC_CLIENT).toBe("TASKS_RPC_CLIENT");
+    expect(TASKS_EVENTS_CLIENT).toBe("TASKS_EVENTS_CLIENT");
+    expect(NOTIFICATIONS_GATEWAY_CLIENT).toBe("NOTIFICATIONS_GATEWAY_CLIENT");
+  });
+});

--- a/apps/auth/tsconfig.json
+++ b/apps/auth/tsconfig.json
@@ -15,8 +15,14 @@
     "outDir": "./dist",
     "baseUrl": "./",
     "paths": {
-      "@repo/types": ["../../packages/types/src/index.ts"],
-      "@repo/types/*": ["../../packages/types/src/*"]
+      "@repo/types": [
+        "../../packages/types/dist-cjs/index.js",
+        "../../packages/types/dist/index.d.ts"
+      ],
+      "@repo/types/*": [
+        "../../packages/types/dist-cjs/*.js",
+        "../../packages/types/dist/*.d.ts"
+      ]
     },
     "incremental": true,
     "skipLibCheck": true,

--- a/apps/notifications/tsconfig.json
+++ b/apps/notifications/tsconfig.json
@@ -15,8 +15,14 @@
     "outDir": "./dist",
     "baseUrl": "./",
     "paths": {
-      "@repo/types": ["../../packages/types/src/index.ts"],
-      "@repo/types/*": ["../../packages/types/src/*"]
+      "@repo/types": [
+        "../../packages/types/dist-cjs/index.js",
+        "../../packages/types/dist/index.d.ts"
+      ],
+      "@repo/types/*": [
+        "../../packages/types/dist-cjs/*.js",
+        "../../packages/types/dist/*.d.ts"
+      ]
     },
     "incremental": true,
     "skipLibCheck": true,

--- a/apps/tasks/tsconfig.json
+++ b/apps/tasks/tsconfig.json
@@ -15,8 +15,14 @@
     "outDir": "./dist",
     "baseUrl": "./",
     "paths": {
-      "@repo/types": ["../../packages/types/src/index.ts"],
-      "@repo/types/*": ["../../packages/types/src/*"]
+      "@repo/types": [
+        "../../packages/types/dist-cjs/index.js",
+        "../../packages/types/dist/index.d.ts"
+      ],
+      "@repo/types/*": [
+        "../../packages/types/dist-cjs/*.js",
+        "../../packages/types/dist/*.d.ts"
+      ]
     },
     "incremental": true,
     "skipLibCheck": true,

--- a/packages/types/src/contracts/auth/index.ts
+++ b/packages/types/src/contracts/auth/index.ts
@@ -1,3 +1,3 @@
 export * from "./messages.js";
-export * from "./schemas.js";
+export type * from "./schemas.js";
 export * from "./codes.js";

--- a/packages/types/src/contracts/common/dtos/index.ts
+++ b/packages/types/src/contracts/common/dtos/index.ts
@@ -1,5 +1,5 @@
-export * from "./user.js";
-export * from "./tokens.js";
-export * from "./task.js";
-export * from "./comment.js";
-export * from "./notification.js";
+export type * from "./user.js";
+export type * from "./tokens.js";
+export type * from "./task.js";
+export type * from "./comment.js";
+export type * from "./notification.js";

--- a/packages/types/src/contracts/common/index.ts
+++ b/packages/types/src/contracts/common/index.ts
@@ -1,1 +1,1 @@
-export * from "./dtos/index.js";
+export type * from "./dtos/index.js";

--- a/packages/types/src/dto/index.ts
+++ b/packages/types/src/dto/index.ts
@@ -1,7 +1,7 @@
 export * from "./auth.js";
-export * from "./comment.js";
-export * from "./notification.js";
 export * from "./task.js";
-export * from "./tokens.js";
-export * from "./user.js";
-export * from "./http.js";
+export type * from "./comment.js";
+export type * from "./notification.js";
+export type * from "./tokens.js";
+export type * from "./user.js";
+export type * from "./http.js";


### PR DESCRIPTION
## Summary
- mark type-only re-exports in `@repo/types` so runtime consumers only see modules with values
- point service tsconfig path aliases at the built `@repo/types` artifacts to match runtime resolution
- add an auth service Jest contract test that exercises the exported message patterns and tokens

## Testing
- pnpm --filter @repo/types build
- pnpm --filter @apps/auth-service exec node -p "require('@repo/types').AUTH_MESSAGE_PATTERNS"
- pnpm --filter @apps/auth-service test -- --runTestsByPath src/types-contracts.spec.ts
- pnpm turbo dev


------
https://chatgpt.com/codex/tasks/task_e_68e5c631b108832ba59c1e56bc50ae52