### PR TITLE
Adjust Turbo build outputs to include library artifacts

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -6,7 +6,12 @@
     "build": {
       "dependsOn": ["^build"],
       "inputs": ["$TURBO_DEFAULT$", ".env*"],
-      "outputs": [".next/**", "!.next/cache/**"]
+      "outputs": [
+        ".next/**",
+        "!.next/cache/**",
+        "dist/**",
+        "dist-cjs/**"
+      ]
     },
     "lint": {
       "dependsOn": ["^lint"]


### PR DESCRIPTION
## Summary
- extend the Turbo build task outputs to cover Next.js and Node library build artifacts

## Testing
- pnpm turbo run build --filter @repo/types
- pnpm turbo dev (manually terminated after verifying services started)

------
https://chatgpt.com/codex/tasks/task_e_68e5c904fb90832bac0788f2577f25d3