### PR TITLE
fix(types): export domain contracts

### DIFF
--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,4 +1,30 @@
-export * from "./dto/index.js";
-export * from "./enums/index.js";
-export * from "./contracts/index.js";
+// Auth
+export * from "./contracts/rpc/auth.js";
+export * from "./contracts/auth/index.js";
+export * from "./dto/auth.js";
+export * from "./enums/auth.js";
+
+// Tasks
+export * from "./contracts/rpc/tasks.js";
+export * from "./contracts/events/tasks.js";
+export * from "./dto/task.js";
+export * from "./enums/task.js";
+
+// Notifications
+export * from "./dto/notification.js";
+export * from "./enums/notification.js";
+
+// Gateway
+export * from "./contracts/events/gateway.js";
+
+// Shared
+export * from "./contracts/queues.js";
+export * from "./contracts/tokens.js";
+export * from "./contracts/common/index.js";
+export * from "./dto/comment.js";
+export * from "./dto/tokens.js";
+export * from "./dto/user.js";
+export * from "./dto/http.js";
+
+// Utils
 export * from "./utils/index.js";


### PR DESCRIPTION
## Summary
- reorganize the @repo/types entrypoint to re-export domain RPC contracts, DTOs, enums, and events
- expose shared queue/token constants and utilities required by the microservices

## Testing
- pnpm turbo run build --filter=@repo/types
- pnpm turbo run dev

------
https://chatgpt.com/codex/tasks/task_e_68e5d597382c832b98ef64ac16e0a188