### PR TITLE
fix: avoid bundling node database utils in web build

### DIFF
--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -25,6 +25,3 @@ export * from "./dto/comment.js";
 export * from "./dto/tokens.js";
 export * from "./dto/user.js";
 export * from "./dto/http.js";
-
-// Utils
-export * from "./utils/index.js";


### PR DESCRIPTION
## Summary
- stop re-exporting the database utilities from the public @repo/types barrel to avoid bundling the pg client in browsers

## Testing
- pnpm --filter @apps/web build *(fails: existing type errors in web package)*

------
https://chatgpt.com/codex/tasks/task_e_68e5e524512c832ba24c2eb90ff2d3df