### PR TITLE
Add reusable API response schema for task endpoints

### DIFF
--- a/apps/web/src/features/tasks/api/createTask.ts
+++ b/apps/web/src/features/tasks/api/createTask.ts
@@ -1,5 +1,7 @@
 import type { CreateTask, Task } from '@repo/types'
 
+import { apiResponseSchema } from '@/schemas/apiResponse'
+
 import { createTaskSchema, taskSchema } from '../schemas/taskSchema'
 import { TASKS_ENDPOINT } from './getTasks'
 
@@ -22,6 +24,7 @@ export async function createTask(payload: CreateTask): Promise<Task> {
   }
 
   const data = await response.json()
+  const parsed = apiResponseSchema(taskSchema).parse(data)
 
-  return taskSchema.parse(data)
+  return parsed.data
 }

--- a/apps/web/src/features/tasks/api/getTaskById.ts
+++ b/apps/web/src/features/tasks/api/getTaskById.ts
@@ -1,5 +1,7 @@
 import type { Task } from '@repo/types'
 
+import { apiResponseSchema } from '@/schemas/apiResponse'
+
 import { taskSchema } from '../schemas/taskSchema'
 import { TASKS_ENDPOINT } from './getTasks'
 
@@ -16,7 +18,11 @@ export async function getTaskById(taskId: string): Promise<Task> {
   }
 
   const data = await response.json()
-  const payload = 'data' in data ? data.data : data
+  const parsed = apiResponseSchema(taskSchema).safeParse(data)
 
-  return taskSchema.parse(payload)
+  if (parsed.success) {
+    return parsed.data.data
+  }
+
+  return taskSchema.parse(data)
 }

--- a/apps/web/src/features/tasks/api/updateTask.ts
+++ b/apps/web/src/features/tasks/api/updateTask.ts
@@ -1,5 +1,7 @@
 import type { Task, UpdateTask } from '@repo/types'
 
+import { apiResponseSchema } from '@/schemas/apiResponse'
+
 import { taskSchema, updateTaskSchema } from '../schemas/taskSchema'
 import { TASKS_ENDPOINT } from './getTasks'
 
@@ -25,6 +27,7 @@ export async function updateTask(
   }
 
   const data = await response.json()
+  const parsed = apiResponseSchema(taskSchema).parse(data)
 
-  return taskSchema.parse(data)
+  return parsed.data
 }

--- a/apps/web/src/schemas/apiResponse.ts
+++ b/apps/web/src/schemas/apiResponse.ts
@@ -1,0 +1,6 @@
+import { z } from 'zod'
+
+export const apiResponseSchema = <T extends z.ZodTypeAny>(schema: T) =>
+  z.object({
+    data: schema,
+  })


### PR DESCRIPTION
## Summary
- add a reusable apiResponseSchema helper to unwrap API payloads
- update task API calls to parse the data envelope and return Task objects directly

## Testing
- pnpm --filter web lint *(fails: None of the selected packages has a "lint" script)*
- pnpm --filter web build *(fails: existing TypeScript errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e680679048832babce91bf74124ef2