### PR TITLE
test(api): cover tasks endpoints

### DIFF
--- a/apps/api/test/__mocks__/contracts.ts
+++ b/apps/api/test/__mocks__/contracts.ts
@@ -1,1 +1,1 @@
-export * from '../../../../packages/types/src/index';
+export * from '../../../../packages/types/dist-cjs/index.js';

--- a/apps/api/test/__mocks__/tasks.fixtures.ts
+++ b/apps/api/test/__mocks__/tasks.fixtures.ts
@@ -1,0 +1,59 @@
+import {
+  TaskPriority,
+  TaskStatus,
+  type CreateTask,
+  type Task,
+  type UpdateTask,
+} from '@repo/types';
+
+export const createTaskFixture = (overrides: Partial<Task> = {}): Task => ({
+  id: '2f1b7b58-9d1f-4a7e-8f6a-2c5d12345678',
+  title: 'Rescue the forest spirit',
+  description: 'Travel to the Whispering Woods and rescue the ancient spirit.',
+  status: TaskStatus.TODO,
+  priority: TaskPriority.MEDIUM,
+  dueDate: '2024-02-01T12:00:00.000Z',
+  assignees: [
+    {
+      id: '5c1f8ad2-6b21-4b5f-b0b9-2d3f1c4e5a6b',
+      username: 'player.one',
+    },
+  ],
+  createdAt: '2024-01-15T08:00:00.000Z',
+  updatedAt: '2024-01-15T08:00:00.000Z',
+  ...overrides,
+});
+
+export const createCreateTaskDtoFixture = (
+  overrides: Partial<CreateTask> = {},
+): CreateTask => ({
+  title: 'Rescue the forest spirit',
+  description: 'Travel to the Whispering Woods and rescue the ancient spirit.',
+  status: TaskStatus.TODO,
+  priority: TaskPriority.MEDIUM,
+  dueDate: '2024-02-01T12:00:00.000Z',
+  assignees: [
+    {
+      id: '5c1f8ad2-6b21-4b5f-b0b9-2d3f1c4e5a6b',
+      username: 'player.one',
+    },
+  ],
+  ...overrides,
+});
+
+export const createUpdateTaskDtoFixture = (
+  overrides: Partial<UpdateTask> = {},
+): UpdateTask => ({
+  title: 'Escort the forest spirit home',
+  status: TaskStatus.IN_PROGRESS,
+  priority: TaskPriority.HIGH,
+  description: 'Ensure the ancient spirit returns safely to the Grove of Echoes.',
+  dueDate: '2024-02-10T12:00:00.000Z',
+  assignees: [
+    {
+      id: '8b2e3c4d-7f6a-4b8c-9d1e-3f2a1b4c5d6e',
+      username: 'player.two',
+    },
+  ],
+  ...overrides,
+});


### PR DESCRIPTION
## Summary
- extend the API e2e suite to mock the tasks RPC client and assert the REST layer for create, update, and delete flows
- add reusable task fixtures for the API tests and load the CommonJS build of shared types for compatibility

## Testing
- pnpm --filter @apps/api-gateway test:e2e

------
https://chatgpt.com/codex/tasks/task_e_68e682dc4764832b9be1509e7688dd1b