### PR TITLE
Fix missing task event handlers in API gateway

### DIFF
--- a/apps/api/src/tasks/tasks.events.controller.ts
+++ b/apps/api/src/tasks/tasks.events.controller.ts
@@ -1,0 +1,87 @@
+import { Controller, Logger } from '@nestjs/common';
+import { Ctx, EventPattern, Payload, RmqContext } from '@nestjs/microservices';
+import { TasksGateway } from './tasks.gateway';
+
+type AcknowledgeMessage = { content: Buffer };
+
+interface AcknowledgeChannel {
+  ack(message: AcknowledgeMessage, allUpTo?: boolean, requeue?: boolean): void;
+}
+
+const isAcknowledgeChannel = (value: unknown): value is AcknowledgeChannel =>
+  typeof value === 'object' &&
+  value !== null &&
+  typeof (value as { ack?: unknown }).ack === 'function';
+
+const isAcknowledgeMessage = (value: unknown): value is AcknowledgeMessage =>
+  typeof value === 'object' &&
+  value !== null &&
+  Buffer.isBuffer((value as { content?: unknown }).content);
+
+@Controller()
+export class TasksEventsController {
+  private readonly logger = new Logger(TasksEventsController.name);
+
+  constructor(private readonly tasksGateway: TasksGateway) {}
+
+  @EventPattern('task.created')
+  onTaskCreated(@Payload() task: unknown, @Ctx() context: RmqContext): void {
+    this.forwardEvent('task:created', task, context);
+  }
+
+  @EventPattern('task.updated')
+  onTaskUpdated(@Payload() task: unknown, @Ctx() context: RmqContext): void {
+    this.forwardEvent('task:updated', task, context);
+  }
+
+  @EventPattern('task.deleted')
+  onTaskDeleted(@Payload() task: unknown, @Ctx() context: RmqContext): void {
+    this.forwardEvent('task:deleted', task, context);
+  }
+
+  @EventPattern('comment.new')
+  onCommentNew(
+    @Payload() comment: unknown,
+    @Ctx() context: RmqContext,
+  ): void {
+    this.forwardEvent('comment:new', comment, context);
+  }
+
+  private forwardEvent(
+    event: string,
+    payload: unknown,
+    context: RmqContext,
+  ): void {
+    try {
+      this.tasksGateway.emitToClients(event, payload);
+    } catch (error) {
+      const messageDetail =
+        error instanceof Error
+          ? error.message
+          : typeof error === 'string'
+            ? error
+            : JSON.stringify(error);
+      const stack = error instanceof Error ? error.stack : undefined;
+      this.logger.error(
+        `Failed to handle RabbitMQ event "${event}": ${messageDetail}`,
+        stack,
+      );
+    } finally {
+      this.acknowledge(context);
+    }
+  }
+
+  private acknowledge(context: RmqContext): void {
+    const channel = context.getChannelRef() as unknown;
+    const originalMessage = context.getMessage() as unknown;
+
+    if (!isAcknowledgeChannel(channel) || !isAcknowledgeMessage(originalMessage)) {
+      this.logger.warn(
+        'Received invalid RabbitMQ context while acknowledging event; message will not be acked.',
+      );
+      return;
+    }
+
+    channel.ack(originalMessage);
+  }
+}

--- a/apps/api/src/tasks/tasks.module.ts
+++ b/apps/api/src/tasks/tasks.module.ts
@@ -5,6 +5,7 @@ import { TasksService } from './tasks.service';
 import { TASKS_RPC_CLIENT, TASKS_RPC_QUEUE } from './tasks.constants';
 import { TasksController } from './tasks.controller';
 import { TasksGateway } from './tasks.gateway';
+import { TasksEventsController } from './tasks.events.controller';
 import { AuthModule } from '../auth/auth.module';
 
 @Module({
@@ -34,7 +35,7 @@ import { AuthModule } from '../auth/auth.module';
       },
     ]),
   ],
-  controllers: [TasksController],
+  controllers: [TasksController, TasksEventsController],
   providers: [TasksService, TasksGateway],
   exports: [TasksService],
 })


### PR DESCRIPTION
## Summary
- move RabbitMQ task event handling into a dedicated TasksEventsController
- keep TasksGateway focused on WebSocket broadcasting and expose a helper to emit events
- register the new controller with the API tasks module so task.created/task.updated messages are processed

## Testing
- pnpm --filter @apps/api-gateway lint *(fails: existing @typescript-eslint no-unsafe-* violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e6841da0f4832bab72a395a2fddd7a