### PR TITLE
feat(api): protect tasks controller with jwt guard

### DIFF
--- a/apps/api/src/tasks/tasks.controller.ts
+++ b/apps/api/src/tasks/tasks.controller.ts
@@ -7,8 +7,14 @@ import {
   Post,
   Put,
   Query,
+  UseGuards,
 } from '@nestjs/common';
-import { ApiCreatedResponse, ApiOkResponse, ApiTags } from '@nestjs/swagger';
+import {
+  ApiBearerAuth,
+  ApiCreatedResponse,
+  ApiOkResponse,
+  ApiTags,
+} from '@nestjs/swagger';
 import {
   CreateTaskDto,
   ListTasksQueryDto,
@@ -20,7 +26,10 @@ import {
 import { TasksService } from './tasks.service';
 import type { PaginatedTasks } from './tasks.service';
 import type { Task } from '@repo/types';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 
+@UseGuards(JwtAuthGuard)
+@ApiBearerAuth()
 @ApiTags('tasks')
 @Controller('tasks')
 export class TasksController {


### PR DESCRIPTION
## Summary
- enforce JWT authentication across TasksController endpoints
- document bearer auth requirement in Swagger for tasks API

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e6a0ab7870832bbb651fa2a918f5e5