### PR TITLE
test: enforce auth in tasks e2e

### DIFF
--- a/apps/api/test/utils/auth.constants.ts
+++ b/apps/api/test/utils/auth.constants.ts
@@ -1,0 +1,3 @@
+export const MOCK_ACCESS_TOKEN = 'token-mock';
+
+export const MOCK_AUTHORIZATION_HEADER = `Bearer ${MOCK_ACCESS_TOKEN}`;


### PR DESCRIPTION
## Summary
- mock the JwtService in the e2e module to accept a reusable fake bearer token
- reuse a shared mock authorization header across tasks endpoint tests
- cover authorized and unauthorized access to the /tasks routes in e2e tests

## Testing
- pnpm --filter @apps/api-gateway test:e2e

------
https://chatgpt.com/codex/tasks/task_e_68e6a566a460832b82b75427ab3daab2