### PR TITLE
docs: document jwt requirements for the gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,135 +1,31 @@
-# Turborepo starter
+# JungleGaming Monorepo
 
-This Turborepo starter is maintained by the Turborepo core team.
+Monorepo Turborepo com os serviços do JungleGaming (gateway HTTP, auth, tasks, notifications e front-end web).
 
-## Using this example
+## Onboarding rápido
+1. Instale dependências com `pnpm install`.
+2. Configure as variáveis de ambiente copiando os arquivos `.env.example` dentro de cada app (ex.: `cp apps/auth/.env.example apps/auth/.env`).
+3. Ajuste os segredos JWT compartilhados entre Auth e API (`JWT_SECRET`, `JWT_EXPIRES_IN`, `JWT_ACCESS_SECRET`, `JWT_ACCESS_EXPIRES`). Os valores precisam coincidir para que a validação do token funcione em todo o ecossistema.
+4. Suba os serviços com `pnpm dev` para desenvolvimento local ou `docker compose up` para a stack completa (Postgres, RabbitMQ e serviços NestJS).
 
-Run the following command:
+## Autenticação e JWT
+- O gateway HTTP (`apps/api`) exige `Authorization: Bearer <accessToken>` em todas as rotas protegidas.
+- Gere o token via `POST /auth/login` ou `POST /auth/register`; o Auth service retorna `accessToken` no corpo e gerencia `refreshToken` via cookie.
+- A documentação interativa está em `http://localhost:3000/api/docs`. Use o botão **Authorize** e informe `Bearer <accessToken>` para testar requisições autenticadas.
+- Tokens podem ser renovados com `POST /auth/refresh`, que lê o `refreshToken` HTTP-only configurado no login.
 
-```sh
-npx create-turbo@latest
-```
+## Estrutura
+- `apps/api`: API Gateway com JWT guard e documentação Swagger.
+- `apps/auth`: serviço de autenticação responsável pela emissão e rotação de tokens.
+- `apps/tasks`: microserviço de tarefas acessado via RPC.
+- `apps/notifications`: entrega de eventos em tempo real via WebSocket.
+- `apps/web`: front-end React/TanStack Router.
+- `packages/*`: bibliotecas compartilhadas (tipos, utils, configs).
 
-## What's inside?
+## Comandos úteis
+- `pnpm dev`: roda os serviços em modo desenvolvimento.
+- `pnpm build`: compila todos os projetos.
+- `pnpm lint`: executa o linting.
+- `pnpm check-types`: valida os tipos TypeScript.
 
-This Turborepo includes the following packages/apps:
-
-### Apps and Packages
-
-- `docs`: a [Next.js](https://nextjs.org/) app
-- `web`: another [Next.js](https://nextjs.org/) app
-- `@repo/ui`: a stub React component library shared by both `web` and `docs` applications
-- `@repo/eslint-config`: `eslint` configurations (includes `eslint-config-next` and `eslint-config-prettier`)
-- `@repo/typescript-config`: `tsconfig.json`s used throughout the monorepo
-
-Each package/app is 100% [TypeScript](https://www.typescriptlang.org/).
-
-### Utilities
-
-This Turborepo has some additional tools already setup for you:
-
-- [TypeScript](https://www.typescriptlang.org/) for static type checking
-- [ESLint](https://eslint.org/) for code linting
-- [Prettier](https://prettier.io) for code formatting
-
-### Build
-
-To build all apps and packages, run the following command:
-
-```
-cd my-turborepo
-
-# With [global `turbo`](https://turborepo.com/docs/getting-started/installation#global-installation) installed (recommended)
-turbo build
-
-# Without [global `turbo`](https://turborepo.com/docs/getting-started/installation#global-installation), use your package manager
-npx turbo build
-yarn dlx turbo build
-pnpm exec turbo build
-```
-
-You can build a specific package by using a [filter](https://turborepo.com/docs/crafting-your-repository/running-tasks#using-filters):
-
-```
-# With [global `turbo`](https://turborepo.com/docs/getting-started/installation#global-installation) installed (recommended)
-turbo build --filter=docs
-
-# Without [global `turbo`](https://turborepo.com/docs/getting-started/installation#global-installation), use your package manager
-npx turbo build --filter=docs
-yarn exec turbo build --filter=docs
-pnpm exec turbo build --filter=docs
-```
-
-### Develop
-
-To develop all apps and packages, run the following command:
-
-```
-cd my-turborepo
-
-# With [global `turbo`](https://turborepo.com/docs/getting-started/installation#global-installation) installed (recommended)
-turbo dev
-
-# Without [global `turbo`](https://turborepo.com/docs/getting-started/installation#global-installation), use your package manager
-npx turbo dev
-yarn exec turbo dev
-pnpm exec turbo dev
-```
-
-You can develop a specific package by using a [filter](https://turborepo.com/docs/crafting-your-repository/running-tasks#using-filters):
-
-```
-# With [global `turbo`](https://turborepo.com/docs/getting-started/installation#global-installation) installed (recommended)
-turbo dev --filter=web
-
-# Without [global `turbo`](https://turborepo.com/docs/getting-started/installation#global-installation), use your package manager
-npx turbo dev --filter=web
-yarn exec turbo dev --filter=web
-pnpm exec turbo dev --filter=web
-```
-
-### Remote Caching
-
-> [!TIP]
-> Vercel Remote Cache is free for all plans. Get started today at [vercel.com](https://vercel.com/signup?/signup?utm_source=remote-cache-sdk&utm_campaign=free_remote_cache).
-
-Turborepo can use a technique known as [Remote Caching](https://turborepo.com/docs/core-concepts/remote-caching) to share cache artifacts across machines, enabling you to share build caches with your team and CI/CD pipelines.
-
-By default, Turborepo will cache locally. To enable Remote Caching you will need an account with Vercel. If you don't have an account you can [create one](https://vercel.com/signup?utm_source=turborepo-examples), then enter the following commands:
-
-```
-cd my-turborepo
-
-# With [global `turbo`](https://turborepo.com/docs/getting-started/installation#global-installation) installed (recommended)
-turbo login
-
-# Without [global `turbo`](https://turborepo.com/docs/getting-started/installation#global-installation), use your package manager
-npx turbo login
-yarn exec turbo login
-pnpm exec turbo login
-```
-
-This will authenticate the Turborepo CLI with your [Vercel account](https://vercel.com/docs/concepts/personal-accounts/overview).
-
-Next, you can link your Turborepo to your Remote Cache by running the following command from the root of your Turborepo:
-
-```
-# With [global `turbo`](https://turborepo.com/docs/getting-started/installation#global-installation) installed (recommended)
-turbo link
-
-# Without [global `turbo`](https://turborepo.com/docs/getting-started/installation#global-installation), use your package manager
-npx turbo link
-yarn exec turbo link
-pnpm exec turbo link
-```
-
-## Useful Links
-
-Learn more about the power of Turborepo:
-
-- [Tasks](https://turborepo.com/docs/crafting-your-repository/running-tasks)
-- [Caching](https://turborepo.com/docs/crafting-your-repository/caching)
-- [Remote Caching](https://turborepo.com/docs/core-concepts/remote-caching)
-- [Filtering](https://turborepo.com/docs/crafting-your-repository/running-tasks#using-filters)
-- [Configuration Options](https://turborepo.com/docs/reference/configuration)
-- [CLI Usage](https://turborepo.com/docs/reference/command-line-reference)
+Consulte `apps/api/README.md` para exemplos detalhados de uso do Swagger e das requisições autenticadas.

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -1,98 +1,44 @@
-<p align="center">
-  <a href="http://nestjs.com/" target="blank"><img src="https://nestjs.com/img/logo-small.svg" width="120" alt="Nest Logo" /></a>
-</p>
+# API Gateway
 
-[circleci-image]: https://img.shields.io/circleci/build/github/nestjs/nest/master?token=abc123def456
-[circleci-url]: https://circleci.com/gh/nestjs/nest
+Este serviço expõe o gateway HTTP da plataforma. Todas as rotas REST protegidas exigem um access token JWT emitido pelo Auth Service.
 
-  <p align="center">A progressive <a href="http://nodejs.org" target="_blank">Node.js</a> framework for building efficient and scalable server-side applications.</p>
-    <p align="center">
-<a href="https://www.npmjs.com/~nestjscore" target="_blank"><img src="https://img.shields.io/npm/v/@nestjs/core.svg" alt="NPM Version" /></a>
-<a href="https://www.npmjs.com/~nestjscore" target="_blank"><img src="https://img.shields.io/npm/l/@nestjs/core.svg" alt="Package License" /></a>
-<a href="https://www.npmjs.com/~nestjscore" target="_blank"><img src="https://img.shields.io/npm/dm/@nestjs/common.svg" alt="NPM Downloads" /></a>
-<a href="https://circleci.com/gh/nestjs/nest" target="_blank"><img src="https://img.shields.io/circleci/build/github/nestjs/nest/master" alt="CircleCI" /></a>
-<a href="https://discord.gg/G7Qnnhy" target="_blank"><img src="https://img.shields.io/badge/discord-online-brightgreen.svg" alt="Discord"/></a>
-<a href="https://opencollective.com/nest#backer" target="_blank"><img src="https://opencollective.com/nest/backers/badge.svg" alt="Backers on Open Collective" /></a>
-<a href="https://opencollective.com/nest#sponsor" target="_blank"><img src="https://opencollective.com/nest/sponsors/badge.svg" alt="Sponsors on Open Collective" /></a>
-  <a href="https://paypal.me/kamilmysliwiec" target="_blank"><img src="https://img.shields.io/badge/Donate-PayPal-ff3f59.svg" alt="Donate us"/></a>
-    <a href="https://opencollective.com/nest#sponsor"  target="_blank"><img src="https://img.shields.io/badge/Support%20us-Open%20Collective-41B883.svg" alt="Support us"></a>
-  <a href="https://twitter.com/nestframework" target="_blank"><img src="https://img.shields.io/twitter/follow/nestframework.svg?style=social&label=Follow" alt="Follow us on Twitter"></a>
-</p>
-  <!--[![Backers on Open Collective](https://opencollective.com/nest/backers/badge.svg)](https://opencollective.com/nest#backer)
-  [![Sponsors on Open Collective](https://opencollective.com/nest/sponsors/badge.svg)](https://opencollective.com/nest#sponsor)-->
+## Documentação Swagger
+- URL padrão local: `http://localhost:3000/api/docs`
+- Clique em **Authorize** e informe `Bearer <accessToken>` para testar chamadas autenticadas diretamente no Swagger.
 
-## Description
+## Obtendo um access token JWT
+1. Garanta que os serviços estejam rodando (por exemplo, com `pnpm dev` ou `docker compose up`).
+2. Registre-se ou faça login pelos endpoints do gateway:
+   - `POST /auth/register`
+   - `POST /auth/login`
+3. O corpo esperado segue o formato:
 
-[Nest](https://github.com/nestjs/nest) framework TypeScript starter repository.
-
-## Project setup
-
-```bash
-$ pnpm install
+```json
+{
+  "email": "usuario@example.com",
+  "password": "senha-segura",
+  "username": "usuario" // apenas no registro
+}
 ```
 
-## Compile and run the project
+Os endpoints retornam `accessToken` e, via cookie HTTP-only, um `refreshToken`.
 
-```bash
-# development
-$ pnpm run start
+### Variáveis de ambiente relacionadas
+- `JWT_SECRET` / `JWT_ACCESS_SECRET`: chave usada para assinar o token (deve ser a mesma do Auth Service).
+- `JWT_EXPIRES_IN` / `JWT_ACCESS_EXPIRES`: tempo de expiração do access token (ex.: `15m`).
 
-# watch mode
-$ pnpm run start:dev
+## Enviando o token nas requisições
+Inclua o header `Authorization` com o esquema Bearer:
 
-# production mode
-$ pnpm run start:prod
+```http
+Authorization: Bearer <accessToken>
 ```
 
-## Run tests
+Exemplo usando `curl`:
 
 ```bash
-# unit tests
-$ pnpm run test
-
-# e2e tests
-$ pnpm run test:e2e
-
-# test coverage
-$ pnpm run test:cov
+curl -H "Authorization: Bearer $ACCESS_TOKEN" \
+     http://localhost:3000/tasks
 ```
 
-## Deployment
-
-When you're ready to deploy your NestJS application to production, there are some key steps you can take to ensure it runs as efficiently as possible. Check out the [deployment documentation](https://docs.nestjs.com/deployment) for more information.
-
-If you are looking for a cloud-based platform to deploy your NestJS application, check out [Mau](https://mau.nestjs.com), our official platform for deploying NestJS applications on AWS. Mau makes deployment straightforward and fast, requiring just a few simple steps:
-
-```bash
-$ pnpm install -g @nestjs/mau
-$ mau deploy
-```
-
-With Mau, you can deploy your application in just a few clicks, allowing you to focus on building features rather than managing infrastructure.
-
-## Resources
-
-Check out a few resources that may come in handy when working with NestJS:
-
-- Visit the [NestJS Documentation](https://docs.nestjs.com) to learn more about the framework.
-- For questions and support, please visit our [Discord channel](https://discord.gg/G7Qnnhy).
-- To dive deeper and get more hands-on experience, check out our official video [courses](https://courses.nestjs.com/).
-- Deploy your application to AWS with the help of [NestJS Mau](https://mau.nestjs.com) in just a few clicks.
-- Visualize your application graph and interact with the NestJS application in real-time using [NestJS Devtools](https://devtools.nestjs.com).
-- Need help with your project (part-time to full-time)? Check out our official [enterprise support](https://enterprise.nestjs.com).
-- To stay in the loop and get updates, follow us on [X](https://x.com/nestframework) and [LinkedIn](https://linkedin.com/company/nestjs).
-- Looking for a job, or have a job to offer? Check out our official [Jobs board](https://jobs.nestjs.com).
-
-## Support
-
-Nest is an MIT-licensed open source project. It can grow thanks to the sponsors and support by the amazing backers. If you'd like to join them, please [read more here](https://docs.nestjs.com/support).
-
-## Stay in touch
-
-- Author - [Kamil Myśliwiec](https://twitter.com/kammysliwiec)
-- Website - [https://nestjs.com](https://nestjs.com/)
-- Twitter - [@nestframework](https://twitter.com/nestframework)
-
-## License
-
-Nest is [MIT licensed](https://github.com/nestjs/nest/blob/master/LICENSE).
+Para renovar o token, utilize `POST /auth/refresh`. O gateway lerá o `refreshToken` do cookie e responderá com um novo `accessToken` pronto para ser enviado no header acima.

--- a/docs/historias.md
+++ b/docs/historias.md
@@ -4,7 +4,7 @@
 * [x] Como usuário, quero **fazer login** e receber `accessToken` (15 min) e `refreshToken` (7 dias), para manter minha sessão ativa com segurança. — feita
 * [x] Como usuário, quero **atualizar meu accessToken** via endpoint de **refresh**, para continuar autenticado sem refazer login. — feita
 * [x] Como sistema, quero **hashear senhas** com bcrypt/argon2, para armazenar credenciais com segurança. — feita
-* [ ] Como API Gateway, quero **proteger rotas** com JWT Guards e expor **Swagger**, para padronizar e documentar o acesso HTTP. _(Observação: Swagger e guard para WebSocket estão ativos, porém os endpoints HTTP de tarefas ainda não utilizam JWT guard.)_
+* [x] Como API Gateway, quero **proteger rotas** com JWT Guards e expor **Swagger**, para padronizar e documentar o acesso HTTP. _(Observação: Swagger segue disponível em `/api/docs` e todos os endpoints HTTP agora exigem JWT via header `Authorization: Bearer <token>`.)_
 
 # Épico: Tarefas (CRUD, Atribuições, Comentários, Histórico)
 


### PR DESCRIPTION
## Summary
- mark the gateway story as done and note that HTTP endpoints now require JWT headers
- rewrite the API README with Swagger URL, token acquisition flow, and bearer header examples
- refresh the root onboarding README with shared JWT environment guidance and gateway usage notes

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e6a6a70340832bb67968f26c5c26a2