### PR TITLE
feat(web): refresh tokens automatically on unauthorized responses

### DIFF
--- a/apps/web/src/features/auth/store.ts
+++ b/apps/web/src/features/auth/store.ts
@@ -36,16 +36,28 @@ export const useAuthStore = create<AuthState>()(
       session: null,
       isAuthenticated: false,
       setAuth: (session) =>
-        set({
-          user: session.user,
-          session,
-          isAuthenticated: true,
+        set(() => {
+          if (typeof window !== 'undefined') {
+            window.localStorage.setItem('accessToken', session.accessToken)
+          }
+
+          return {
+            user: session.user,
+            session,
+            isAuthenticated: true,
+          }
         }),
       clearAuth: () =>
-        set({
-          user: null,
-          session: null,
-          isAuthenticated: false,
+        set(() => {
+          if (typeof window !== 'undefined') {
+            window.localStorage.removeItem('accessToken')
+          }
+
+          return {
+            user: null,
+            session: null,
+            isAuthenticated: false,
+          }
         }),
     }),
     {

--- a/apps/web/src/features/tasks/api/createTask.ts
+++ b/apps/web/src/features/tasks/api/createTask.ts
@@ -1,5 +1,6 @@
 import type { CreateTask, Task } from '@repo/types'
 
+import { fetchWithAuth } from '@/lib/apiClient'
 import { apiResponseSchema } from '@/schemas/apiResponse'
 
 import { createTaskSchema, taskSchema } from '../schemas/taskSchema'
@@ -8,9 +9,8 @@ import { TASKS_ENDPOINT } from './getTasks'
 export async function createTask(payload: CreateTask): Promise<Task> {
   const body = createTaskSchema.parse(payload)
 
-  const response = await fetch(TASKS_ENDPOINT, {
+  const response = await fetchWithAuth(TASKS_ENDPOINT, {
     method: 'POST',
-    credentials: 'include',
     headers: {
       'Content-Type': 'application/json',
     },

--- a/apps/web/src/features/tasks/api/deleteTask.ts
+++ b/apps/web/src/features/tasks/api/deleteTask.ts
@@ -1,9 +1,10 @@
+import { fetchWithAuth } from '@/lib/apiClient'
+
 import { TASKS_ENDPOINT } from './getTasks'
 
 export async function deleteTask(taskId: string): Promise<void> {
-  const response = await fetch(`${TASKS_ENDPOINT}/${taskId}`, {
+  const response = await fetchWithAuth(`${TASKS_ENDPOINT}/${taskId}`, {
     method: 'DELETE',
-    credentials: 'include',
   })
 
   if (!response.ok) {

--- a/apps/web/src/features/tasks/api/getTaskById.ts
+++ b/apps/web/src/features/tasks/api/getTaskById.ts
@@ -3,12 +3,13 @@ import type { Task } from '@repo/types'
 import { apiResponseSchema } from '@/schemas/apiResponse'
 
 import { taskSchema } from '../schemas/taskSchema'
+import { fetchWithAuth } from '@/lib/apiClient'
+
 import { TASKS_ENDPOINT } from './getTasks'
 
 export async function getTaskById(taskId: string): Promise<Task> {
-  const response = await fetch(`${TASKS_ENDPOINT}/${taskId}`, {
+  const response = await fetchWithAuth(`${TASKS_ENDPOINT}/${taskId}`, {
     method: 'GET',
-    credentials: 'include',
   })
 
   if (!response.ok) {

--- a/apps/web/src/features/tasks/api/getTaskComments.ts
+++ b/apps/web/src/features/tasks/api/getTaskComments.ts
@@ -1,12 +1,13 @@
 import type { CommentDTO } from '@repo/types'
 
 import { commentSchema } from '../schemas/commentSchema'
+import { fetchWithAuth } from '@/lib/apiClient'
+
 import { TASKS_ENDPOINT } from './getTasks'
 
 export async function getTaskComments(taskId: string): Promise<CommentDTO[]> {
-  const response = await fetch(`${TASKS_ENDPOINT}/${taskId}/comments`, {
+  const response = await fetchWithAuth(`${TASKS_ENDPOINT}/${taskId}/comments`, {
     method: 'GET',
-    credentials: 'include',
   })
 
   if (!response.ok) {

--- a/apps/web/src/features/tasks/api/getTaskNotifications.ts
+++ b/apps/web/src/features/tasks/api/getTaskNotifications.ts
@@ -1,14 +1,15 @@
 import type { NotificationDTO } from '@repo/types'
 
 import { notificationSchema } from '../schemas/notificationSchema'
+import { fetchWithAuth } from '@/lib/apiClient'
+
 import { TASKS_ENDPOINT } from './getTasks'
 
 export async function getTaskNotifications(
   taskId: string,
 ): Promise<NotificationDTO[]> {
-  const response = await fetch(`${TASKS_ENDPOINT}/${taskId}/notifications`, {
+  const response = await fetchWithAuth(`${TASKS_ENDPOINT}/${taskId}/notifications`, {
     method: 'GET',
-    credentials: 'include',
   })
 
   if (!response.ok) {

--- a/apps/web/src/features/tasks/api/getTasks.ts
+++ b/apps/web/src/features/tasks/api/getTasks.ts
@@ -1,11 +1,10 @@
 import type { Task, TaskPriority, TaskStatus } from '@repo/types'
 import { z } from 'zod'
 
-import { env } from '@/env'
+import { API_BASE_URL, fetchWithAuth } from '@/lib/apiClient'
 
 import { taskSchema } from '../schemas/taskSchema'
 
-const API_BASE_URL = env.VITE_API_BASE_URL?.replace(/\/$/, '') ?? ''
 const TASKS_ENDPOINT = API_BASE_URL ? `${API_BASE_URL}/tasks` : '/api/tasks'
 
 const paginatedTasksSchema = z.object({
@@ -45,9 +44,8 @@ function buildTasksUrl(filters?: GetTasksFilters) {
 }
 
 export async function getTasks(filters?: GetTasksFilters): Promise<Task[]> {
-  const response = await fetch(buildTasksUrl(filters), {
+  const response = await fetchWithAuth(buildTasksUrl(filters), {
     method: 'GET',
-    credentials: 'include',
   })
 
   if (!response.ok) {

--- a/apps/web/src/features/tasks/api/updateTask.ts
+++ b/apps/web/src/features/tasks/api/updateTask.ts
@@ -1,5 +1,6 @@
 import type { Task, UpdateTask } from '@repo/types'
 
+import { fetchWithAuth } from '@/lib/apiClient'
 import { apiResponseSchema } from '@/schemas/apiResponse'
 
 import { taskSchema, updateTaskSchema } from '../schemas/taskSchema'
@@ -11,9 +12,8 @@ export async function updateTask(
 ): Promise<Task> {
   const body = updateTaskSchema.parse(payload)
 
-  const response = await fetch(`${TASKS_ENDPOINT}/${taskId}`, {
+  const response = await fetchWithAuth(`${TASKS_ENDPOINT}/${taskId}`, {
     method: 'PUT',
-    credentials: 'include',
     headers: {
       'Content-Type': 'application/json',
     },

--- a/apps/web/src/lib/apiClient.ts
+++ b/apps/web/src/lib/apiClient.ts
@@ -1,0 +1,119 @@
+import type { AuthSession } from '@repo/types'
+
+import { env } from '@/env'
+import { useAuthStore } from '@/features/auth/store'
+
+const API_BASE_URL = env.VITE_API_BASE_URL?.replace(/\/$/, '') ?? ''
+const REFRESH_ENDPOINT = API_BASE_URL
+  ? `${API_BASE_URL}/auth/refresh`
+  : '/api/auth/refresh'
+
+type FetchInput = Parameters<typeof fetch>[0]
+type FetchInit = Parameters<typeof fetch>[1]
+
+function resolveCredentials(init?: FetchInit): RequestCredentials {
+  if (init?.credentials) {
+    return init.credentials
+  }
+
+  return 'include'
+}
+
+function shouldSkipRefresh(input: FetchInput): boolean {
+  const url =
+    typeof input === 'string'
+      ? input
+      : input instanceof URL
+        ? input.toString()
+        : input.url
+
+  return (
+    url.includes('/auth/login') ||
+    url.includes('/auth/register') ||
+    url.includes('/auth/refresh')
+  )
+}
+
+async function refreshAccessToken(): Promise<string | null> {
+  const { session, setAuth, clearAuth } = useAuthStore.getState()
+
+  if (!session?.user) {
+    clearAuth()
+    return null
+  }
+
+  try {
+    const response = await fetch(REFRESH_ENDPOINT, {
+      method: 'POST',
+      credentials: 'include',
+    })
+
+    if (!response.ok) {
+      clearAuth()
+      return null
+    }
+
+    const data = (await response.json()) as { accessToken: string }
+    const updatedSession: AuthSession = {
+      user: session.user,
+      accessToken: data.accessToken,
+    }
+
+    setAuth(updatedSession)
+
+    return data.accessToken
+  } catch (error) {
+    console.error('Failed to refresh access token', error)
+    clearAuth()
+    return null
+  }
+}
+
+function applyAuthHeader(headers: Headers, accessToken?: string | null) {
+  if (!accessToken || headers.has('Authorization')) {
+    return
+  }
+
+  headers.set('Authorization', `Bearer ${accessToken}`)
+}
+
+export async function fetchWithAuth(
+  input: FetchInput,
+  init?: FetchInit,
+): Promise<Response> {
+  const headers = new Headers(init?.headers)
+  const { session, clearAuth } = useAuthStore.getState()
+
+  applyAuthHeader(headers, session?.accessToken)
+
+  const credentials = resolveCredentials(init)
+
+  const response = await fetch(input, { ...init, headers, credentials })
+
+  if (response.status !== 401 || shouldSkipRefresh(input)) {
+    return response
+  }
+
+  const refreshedToken = await refreshAccessToken()
+
+  if (!refreshedToken) {
+    return response
+  }
+
+  const retryHeaders = new Headers(init?.headers)
+  applyAuthHeader(retryHeaders, refreshedToken)
+
+  const retryResponse = await fetch(input, {
+    ...init,
+    headers: retryHeaders,
+    credentials,
+  })
+
+  if (retryResponse.status === 401) {
+    clearAuth()
+  }
+
+  return retryResponse
+}
+
+export { API_BASE_URL }


### PR DESCRIPTION
## Summary
- add a shared authenticated fetch helper that refreshes tokens on 401 responses
- persist the access token in the auth store so it is available for retries and sockets
- update all task API requests to use the authenticated fetch helper

## Testing
- pnpm --filter web test

------
https://chatgpt.com/codex/tasks/task_e_68e69ff52898832b953e48f5058faef3