### PR TITLE
feat(tasks): add comment management support

### DIFF
--- a/apps/tasks/src/app.module.ts
+++ b/apps/tasks/src/app.module.ts
@@ -4,6 +4,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { HealthModule } from './health/health.module';
 import { TasksModule } from './tasks/tasks.module';
 import { Task } from './tasks/task.entity';
+import { Comment } from './comments/comment.entity';
 
 const validateEnv = (config: Record<string, unknown>) => {
   const databaseUrl = config['DATABASE_URL'];
@@ -30,7 +31,7 @@ const validateEnv = (config: Record<string, unknown>) => {
         url: configService.getOrThrow<string>('DATABASE_URL'),
         autoLoadEntities: true,
         synchronize: true,
-        entities: [Task],
+        entities: [Task, Comment],
       }),
     }),
     HealthModule,

--- a/apps/tasks/src/comments/comment.entity.ts
+++ b/apps/tasks/src/comments/comment.entity.ts
@@ -1,0 +1,35 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { Task } from '../tasks/task.entity';
+
+@Entity({ name: 'task_comments' })
+export class Comment {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'uuid' })
+  taskId: string;
+
+  @ManyToOne(() => Task, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'taskId' })
+  task?: Task;
+
+  @Column({ type: 'uuid' })
+  authorId: string;
+
+  @Column({ type: 'text' })
+  message: string;
+
+  @CreateDateColumn({ type: 'timestamptz' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ type: 'timestamptz' })
+  updatedAt: Date;
+}

--- a/apps/tasks/src/comments/comments.controller.ts
+++ b/apps/tasks/src/comments/comments.controller.ts
@@ -1,0 +1,34 @@
+import { Controller } from '@nestjs/common';
+import { MessagePattern, Payload } from '@nestjs/microservices';
+import { CommentsService, PaginatedComments } from './comments.service';
+import {
+  CreateCommentDto,
+  ListTaskCommentsDto,
+  TASKS_MESSAGE_PATTERNS,
+} from '@repo/types';
+import { transformPayload, toRpcException } from '../common/rpc.utils';
+
+@Controller()
+export class CommentsController {
+  constructor(private readonly commentsService: CommentsService) {}
+
+  @MessagePattern(TASKS_MESSAGE_PATTERNS.COMMENT_CREATE)
+  async create(@Payload() payload: unknown) {
+    try {
+      const dto = transformPayload(CreateCommentDto, payload);
+      return await this.commentsService.create(dto);
+    } catch (error) {
+      throw toRpcException(error);
+    }
+  }
+
+  @MessagePattern(TASKS_MESSAGE_PATTERNS.COMMENT_FIND_ALL)
+  async findAll(@Payload() payload: unknown): Promise<PaginatedComments> {
+    try {
+      const dto = transformPayload(ListTaskCommentsDto, payload ?? {});
+      return await this.commentsService.findAll(dto);
+    } catch (error) {
+      throw toRpcException(error);
+    }
+  }
+}

--- a/apps/tasks/src/comments/comments.service.spec.ts
+++ b/apps/tasks/src/comments/comments.service.spec.ts
@@ -1,0 +1,143 @@
+import type { ClientProxy } from '@nestjs/microservices';
+import { randomUUID } from 'node:crypto';
+import { of } from 'rxjs';
+import { DataSource, Repository } from 'typeorm';
+import { Comment } from './comment.entity';
+import { CommentsService } from './comments.service';
+import { Task } from '../tasks/task.entity';
+import { createTestDataSource } from '../testing/database';
+import {
+  TaskPriority,
+  TaskStatus,
+  TASK_FORWARDING_PATTERNS,
+} from '@repo/types';
+
+describe('CommentsService', () => {
+  let dataSource: DataSource;
+  let commentsRepository: Repository<Comment>;
+  let tasksRepository: Repository<Task>;
+  let service: CommentsService;
+  const emitMock = jest.fn(() => of(undefined));
+  const eventsClient = { emit: emitMock } as unknown as ClientProxy;
+
+  beforeAll(async () => {
+    dataSource = await createTestDataSource([Task, Comment]);
+    commentsRepository = dataSource.getRepository(Comment);
+    tasksRepository = dataSource.getRepository(Task);
+    service = new CommentsService(
+      commentsRepository,
+      tasksRepository,
+      eventsClient,
+    );
+  });
+
+  afterEach(async () => {
+    emitMock.mockClear();
+    await commentsRepository.createQueryBuilder().delete().from(Comment).execute();
+    await tasksRepository.createQueryBuilder().delete().from(Task).execute();
+  });
+
+  afterAll(async () => {
+    await dataSource.destroy();
+  });
+
+  it('throws a NotFoundException when creating a comment for a missing task', async () => {
+    await expect(
+      service.create({
+        taskId: randomUUID(),
+        authorId: randomUUID(),
+        message: 'Hello world',
+      }),
+    ).rejects.toThrow('Task not found');
+  });
+
+  it('creates a comment and emits a forwarding event with unique recipients', async () => {
+    const authorId = randomUUID();
+    const assigneeId = randomUUID();
+    const task = await tasksRepository.save(
+      tasksRepository.create({
+        title: 'Sample task',
+        description: null,
+        status: TaskStatus.TODO,
+        priority: TaskPriority.MEDIUM,
+        dueDate: null,
+        assignees: [
+          { id: assigneeId, username: 'assignee-1' },
+          { id: authorId, username: 'author' },
+        ],
+      }),
+    );
+
+    const comment = await service.create({
+      taskId: task.id,
+      authorId,
+      message: 'First comment',
+    });
+
+    expect(comment.id).toBeDefined();
+    expect(comment.taskId).toBe(task.id);
+    expect(comment.message).toBe('First comment');
+
+    expect(emitMock).toHaveBeenCalledWith(
+      TASK_FORWARDING_PATTERNS.COMMENT_CREATED,
+      expect.objectContaining({
+        comment: expect.objectContaining({ id: comment.id, message: 'First comment' }),
+        recipients: expect.arrayContaining([authorId, assigneeId]),
+      }),
+    );
+
+    const payload = emitMock.mock.calls[0][1];
+    expect(new Set(payload.recipients).size).toBe(payload.recipients.length);
+  });
+
+  it('throws a NotFoundException when listing comments for a missing task', async () => {
+    await expect(
+      service.findAll({ taskId: randomUUID() }),
+    ).rejects.toThrow('Task not found');
+  });
+
+  it('lists comments with pagination defaults applied and ordered by creation date', async () => {
+    const author1 = randomUUID();
+    const author2 = randomUUID();
+    const author3 = randomUUID();
+    const task = await tasksRepository.save(
+      tasksRepository.create({
+        title: 'Paginated task',
+        description: null,
+        status: TaskStatus.TODO,
+        priority: TaskPriority.MEDIUM,
+        dueDate: null,
+        assignees: [],
+      }),
+    );
+
+    await service.create({
+      taskId: task.id,
+      authorId: author1,
+      message: 'First',
+    });
+    await service.create({
+      taskId: task.id,
+      authorId: author2,
+      message: 'Second',
+    });
+    await service.create({
+      taskId: task.id,
+      authorId: author3,
+      message: 'Third',
+    });
+
+    const result = await service.findAll({
+      taskId: task.id,
+      page: 0,
+      limit: 0,
+    });
+
+    expect(result.page).toBe(1);
+    expect(result.limit).toBe(10);
+    expect(result.total).toBe(3);
+    expect(result.data).toHaveLength(3);
+    expect(result.data[0].message).toBe('Third');
+    expect(result.data[2].message).toBe('First');
+  });
+});

--- a/apps/tasks/src/comments/comments.service.ts
+++ b/apps/tasks/src/comments/comments.service.ts
@@ -1,0 +1,120 @@
+import { Inject, Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { ClientProxy } from '@nestjs/microservices';
+import { defaultIfEmpty, lastValueFrom } from 'rxjs';
+import { Repository } from 'typeorm';
+import { Comment } from './comment.entity';
+import { Task } from '../tasks/task.entity';
+import { TASKS_EVENTS_CLIENT } from '../tasks/tasks.constants';
+import {
+  TASK_FORWARDING_PATTERNS,
+  type CommentDTO,
+  type CreateCommentDTO,
+  type PaginatedCommentsDTO,
+  type TaskCommentListFiltersDTO,
+  type TaskCommentCreatedPayload,
+  type TaskForwardingPattern,
+} from '@repo/types';
+
+export interface PaginatedComments extends PaginatedCommentsDTO {
+  data: Comment[];
+}
+
+@Injectable()
+export class CommentsService {
+  constructor(
+    @InjectRepository(Comment)
+    private readonly commentsRepository: Repository<Comment>,
+    @InjectRepository(Task)
+    private readonly tasksRepository: Repository<Task>,
+    @Inject(TASKS_EVENTS_CLIENT)
+    private readonly eventsClient: ClientProxy,
+  ) {}
+
+  async create(dto: CreateCommentDTO): Promise<Comment> {
+    const task = await this.findTaskOrFail(dto.taskId);
+
+    const comment = this.commentsRepository.create(dto);
+    const saved = await this.commentsRepository.save(comment);
+
+    await this.emitCommentCreated(saved, task);
+
+    return saved;
+  }
+
+  async findAll(filters: TaskCommentListFiltersDTO): Promise<PaginatedComments> {
+    await this.findTaskOrFail(filters.taskId);
+
+    const page = filters.page && filters.page > 0 ? filters.page : 1;
+    const limit = filters.limit && filters.limit > 0 ? filters.limit : 10;
+
+    const [data, total] = await this.commentsRepository.findAndCount({
+      where: { taskId: filters.taskId },
+      order: { createdAt: 'DESC' },
+      skip: (page - 1) * limit,
+      take: limit,
+    });
+
+    return {
+      data,
+      total,
+      page,
+      limit,
+    };
+  }
+
+  private async findTaskOrFail(taskId: string): Promise<Task> {
+    const task = await this.tasksRepository.findOne({ where: { id: taskId } });
+
+    if (!task) {
+      throw new NotFoundException('Task not found');
+    }
+
+    return task;
+  }
+
+  private async emitCommentCreated(comment: Comment, task: Task): Promise<void> {
+    const recipients = new Set<string>();
+
+    if (comment.authorId) {
+      recipients.add(comment.authorId);
+    }
+
+    for (const assignee of task.assignees ?? []) {
+      if (assignee?.id) {
+        recipients.add(assignee.id);
+      }
+    }
+
+    const payload: TaskCommentCreatedPayload = {
+      comment: this.toCommentDTO(comment),
+      recipients: Array.from(recipients),
+    };
+
+    await this.emitEvent(TASK_FORWARDING_PATTERNS.COMMENT_CREATED, payload);
+  }
+
+  private toCommentDTO(comment: Comment): CommentDTO {
+    return {
+      id: comment.id,
+      taskId: comment.taskId,
+      authorId: comment.authorId,
+      message: comment.message,
+      createdAt: comment.createdAt.toISOString(),
+      updatedAt: comment.updatedAt.toISOString(),
+    };
+  }
+
+  private async emitEvent(
+    pattern: TaskForwardingPattern,
+    payload: unknown,
+  ): Promise<void> {
+    try {
+      await lastValueFrom(
+        this.eventsClient.emit(pattern, payload).pipe(defaultIfEmpty(undefined)),
+      );
+    } catch {
+      // Intentionally swallow errors to avoid breaking the main workflow
+    }
+  }
+}

--- a/apps/tasks/src/common/rpc.utils.ts
+++ b/apps/tasks/src/common/rpc.utils.ts
@@ -1,0 +1,44 @@
+import { BadRequestException, HttpException } from '@nestjs/common';
+import { RpcException } from '@nestjs/microservices';
+import { plainToInstance } from 'class-transformer';
+import { validateSync } from 'class-validator';
+
+export function transformPayload<T>(cls: new () => T, payload: unknown): T {
+  const dto = plainToInstance(cls, payload, {
+    enableImplicitConversion: true,
+    exposeDefaultValues: true,
+  });
+
+  const errors = validateSync(dto as object, {
+    whitelist: true,
+    forbidUnknownValues: true,
+    forbidNonWhitelisted: true,
+  });
+
+  if (errors.length > 0) {
+    throw new BadRequestException(errors);
+  }
+
+  return dto;
+}
+
+export function toRpcException(error: unknown): RpcException {
+  if (error instanceof RpcException) {
+    return error;
+  }
+
+  if (error instanceof HttpException) {
+    return new RpcException({
+      status: error.getStatus(),
+      response: error.getResponse(),
+    });
+  }
+
+  if (error instanceof Error) {
+    return new RpcException({
+      message: error.message,
+    });
+  }
+
+  return new RpcException(error as Record<string, unknown>);
+}

--- a/apps/tasks/src/tasks/tasks.module.ts
+++ b/apps/tasks/src/tasks/tasks.module.ts
@@ -6,10 +6,13 @@ import { Task } from './task.entity';
 import { TasksService } from './tasks.service';
 import { TasksController } from './tasks.controller';
 import { TASKS_EVENTS_CLIENT, TASKS_EVENTS_QUEUE } from './tasks.constants';
+import { Comment } from '../comments/comment.entity';
+import { CommentsService } from '../comments/comments.service';
+import { CommentsController } from '../comments/comments.controller';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Task]),
+    TypeOrmModule.forFeature([Task, Comment]),
     ConfigModule,
     ClientsModule.registerAsync([
       {
@@ -34,8 +37,8 @@ import { TASKS_EVENTS_CLIENT, TASKS_EVENTS_QUEUE } from './tasks.constants';
       },
     ]),
   ],
-  controllers: [TasksController],
-  providers: [TasksService],
+  controllers: [TasksController, CommentsController],
+  providers: [TasksService, CommentsService],
   exports: [TypeOrmModule, TasksService],
 })
 export class TasksModule {}

--- a/apps/tasks/src/testing/database.ts
+++ b/apps/tasks/src/testing/database.ts
@@ -1,0 +1,36 @@
+import { randomUUID } from 'node:crypto';
+import { DataSource, EntityTarget } from 'typeorm';
+import { newDb } from 'pg-mem';
+
+export async function createTestDataSource(
+  entities: EntityTarget<unknown>[],
+): Promise<DataSource> {
+  const db = newDb({ autoCreateForeignKeyIndices: true });
+
+  db.public.registerFunction({
+    name: 'version',
+    returns: 'text',
+    implementation: () => 'PostgreSQL 13.3',
+  });
+  db.public.registerFunction({
+    name: 'current_database',
+    returns: 'text',
+    implementation: () => 'test',
+  });
+  db.public.registerFunction({
+    name: 'uuid_generate_v4',
+    returns: 'uuid',
+    implementation: () => randomUUID(),
+    impure: true,
+  });
+
+  const dataSourceFactory = db.adapters.createTypeormDataSource({
+    type: 'postgres',
+    entities,
+  });
+
+  const dataSource = await dataSourceFactory.initialize();
+  await dataSource.synchronize();
+
+  return dataSource;
+}


### PR DESCRIPTION
## Summary
- add a task comment entity, service, and controller for creating and listing comments while emitting forwarding events
- share RPC validation utilities between controllers and register the new comment components in the tasks application modules
- extend the pg-mem testing harness and cover comment workflows alongside existing task service tests

## Testing
- pnpm --filter @apps/tasks-service test

------
https://chatgpt.com/codex/tasks/task_e_68e6b5708b40832babba219493490396