### PR TITLE
feat(api): add task comment endpoints

### DIFF
--- a/apps/api/src/auth/current-user.decorator.ts
+++ b/apps/api/src/auth/current-user.decorator.ts
@@ -1,0 +1,37 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+import type { Request } from 'express';
+
+export interface CurrentUserPayload {
+  sub: string;
+  email?: string;
+  name?: string;
+  [key: string]: unknown;
+}
+
+export const CurrentUser = createParamDecorator(
+  <T extends keyof CurrentUserPayload | undefined>(
+    data: T,
+    context: ExecutionContext,
+  ): T extends keyof CurrentUserPayload
+    ? CurrentUserPayload[T]
+    : CurrentUserPayload | undefined => {
+    if (context.getType() !== 'http') {
+      return undefined as never;
+    }
+
+    const request = context
+      .switchToHttp()
+      .getRequest<Request & { user?: CurrentUserPayload }>();
+    const user = request.user;
+
+    if (!user) {
+      return undefined as never;
+    }
+
+    if (data && typeof data === 'string') {
+      return (user as CurrentUserPayload)[data] as never;
+    }
+
+    return user as never;
+  },
+);

--- a/apps/api/src/tasks/tasks.service.ts
+++ b/apps/api/src/tasks/tasks.service.ts
@@ -13,9 +13,13 @@ import {
 import { ClientProxy, RpcException } from '@nestjs/microservices';
 import { lastValueFrom } from 'rxjs';
 import type {
+  Comment,
+  CreateComment,
   CreateTask,
+  PaginatedComments as PaginatedCommentsResult,
   PaginatedTasks as PaginatedTasksResult,
   Task,
+  TaskCommentListFilters,
   TaskListFilters,
   TasksMessagePattern,
   UpdateTask,
@@ -25,6 +29,9 @@ import { TASKS_RPC_CLIENT } from './tasks.constants';
 
 export type ListTasksFilters = TaskListFilters;
 export type PaginatedTasks = PaginatedTasksResult;
+export type PaginatedComments = PaginatedCommentsResult;
+export type ListTaskCommentsFilters = Omit<TaskCommentListFilters, 'taskId'>;
+export type CreateTaskComment = Omit<CreateComment, 'taskId'>;
 
 @Injectable()
 export class TasksService {
@@ -51,6 +58,29 @@ export class TasksService {
 
   async remove(id: string): Promise<Task> {
     return this.send<Task>(TASKS_MESSAGE_PATTERNS.REMOVE, { id });
+  }
+
+  async listComments(
+    taskId: string,
+    filters: ListTaskCommentsFilters = {},
+  ): Promise<PaginatedComments> {
+    return this.send<PaginatedComments>(
+      TASKS_MESSAGE_PATTERNS.COMMENT_FIND_ALL,
+      {
+        taskId,
+        ...filters,
+      },
+    );
+  }
+
+  async createComment(
+    taskId: string,
+    data: CreateTaskComment,
+  ): Promise<Comment> {
+    return this.send<Comment>(TASKS_MESSAGE_PATTERNS.COMMENT_CREATE, {
+      taskId,
+      ...data,
+    });
   }
 
   private async send<TResponse>(

--- a/apps/api/test/__mocks__/comments.fixtures.ts
+++ b/apps/api/test/__mocks__/comments.fixtures.ts
@@ -1,0 +1,23 @@
+import type { Comment, PaginatedComments } from '@repo/types';
+
+export const createCommentFixture = (
+  overrides: Partial<Comment> = {},
+): Comment => ({
+  id: 'c1b2d3e4-f5a6-4b7c-8d9e-0f1a2b3c4d5e',
+  taskId: '2f1b7b58-9d1f-4a7e-8f6a-2c5d12345678',
+  authorId: 'user-1',
+  message: 'Great work on this task!',
+  createdAt: '2024-01-15T09:30:00.000Z',
+  updatedAt: '2024-01-15T09:30:00.000Z',
+  ...overrides,
+});
+
+export const createPaginatedCommentsFixture = (
+  overrides: Partial<PaginatedComments> = {},
+): PaginatedComments => ({
+  data: [createCommentFixture()],
+  total: 1,
+  page: 1,
+  limit: 10,
+  ...overrides,
+});


### PR DESCRIPTION
## Summary
- add a CurrentUser decorator for extracting the authenticated request payload
- expose RPC-backed comment listing and creation in the tasks controller and service
- expand e2e coverage with comment fixtures and new scenarios

## Testing
- pnpm --filter @apps/api-gateway test:e2e

------
https://chatgpt.com/codex/tasks/task_e_68e6b7b35150832bb732de47a82361d0