### PR TITLE
feat(web): add paginated task comments

### DIFF
--- a/apps/web/src/features/tasks/api/createTaskComment.ts
+++ b/apps/web/src/features/tasks/api/createTaskComment.ts
@@ -1,0 +1,39 @@
+import type { Comment } from '@repo/types'
+
+import { fetchWithAuth } from '@/lib/apiClient'
+import { apiResponseSchema } from '@/schemas/apiResponse'
+
+import { commentFormSchema, commentSchema } from '../schemas/commentSchema'
+import { TASKS_ENDPOINT } from './getTasks'
+
+export interface CreateTaskCommentInput {
+  message: string
+}
+
+export async function createTaskComment(
+  taskId: string,
+  input: CreateTaskCommentInput,
+): Promise<Comment> {
+  const parsedInput = commentFormSchema.parse({
+    message: input.message.trim(),
+  })
+
+  const response = await fetchWithAuth(`${TASKS_ENDPOINT}/${taskId}/comments`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(parsedInput),
+  })
+
+  if (!response.ok) {
+    throw new Error(
+      `Falha ao criar comentário: ${response.status} ${response.statusText}`,
+    )
+  }
+
+  const data = await response.json()
+  const parsed = apiResponseSchema(commentSchema).parse(data)
+
+  return parsed.data
+}

--- a/apps/web/src/features/tasks/pages/TasksPage.tsx
+++ b/apps/web/src/features/tasks/pages/TasksPage.tsx
@@ -93,24 +93,9 @@ export function TasksPage() {
     }
 
     const handleCommentNew = (comment: CommentDTO) => {
-      queryClient.setQueryData<CommentDTO[] | undefined>(
-        ['task', comment.taskId, 'comments'],
-        (previousComments) => {
-          if (!previousComments) {
-            return previousComments
-          }
-
-          const alreadyExists = previousComments.some(
-            (existingComment) => existingComment.id === comment.id,
-          )
-
-          if (alreadyExists) {
-            return previousComments
-          }
-
-          return [...previousComments, comment]
-        },
-      )
+      void queryClient.invalidateQueries({
+        queryKey: ['task', comment.taskId, 'comments'],
+      })
 
       void queryClient.invalidateQueries({
         queryKey: ['task', comment.taskId, 'notifications'],

--- a/apps/web/src/features/tasks/pages/__tests__/TaskDetailsPage.test.ts
+++ b/apps/web/src/features/tasks/pages/__tests__/TaskDetailsPage.test.ts
@@ -1,0 +1,47 @@
+import 'reflect-metadata'
+
+import { describe, expect, it } from 'vitest'
+
+import type { PaginationMeta } from '@repo/types'
+
+import { getCommentsDisplayRange } from '../TaskDetailsPage'
+
+describe('getCommentsDisplayRange', () => {
+  it('retorna zeros quando não há metadados ou comentários', () => {
+    expect(getCommentsDisplayRange(undefined, 0)).toEqual({
+      start: 0,
+      end: 0,
+      total: 0,
+    })
+  })
+
+  it('calcula o intervalo exibido com base na página atual', () => {
+    const meta: PaginationMeta = {
+      total: 12,
+      page: 1,
+      size: 5,
+      totalPages: 3,
+    }
+
+    expect(getCommentsDisplayRange(meta, 5)).toEqual({
+      start: 1,
+      end: 5,
+      total: 12,
+    })
+  })
+
+  it('respeita o total ao calcular o fim do intervalo', () => {
+    const meta: PaginationMeta = {
+      total: 12,
+      page: 3,
+      size: 5,
+      totalPages: 3,
+    }
+
+    expect(getCommentsDisplayRange(meta, 2)).toEqual({
+      start: 11,
+      end: 12,
+      total: 12,
+    })
+  })
+})

--- a/apps/web/src/features/tasks/schemas/commentSchema.ts
+++ b/apps/web/src/features/tasks/schemas/commentSchema.ts
@@ -1,3 +1,4 @@
+import { COMMENT_MESSAGE_MAX_LENGTH } from '@repo/types'
 import { z } from 'zod'
 
 export const commentSchema = z.object({
@@ -9,4 +10,15 @@ export const commentSchema = z.object({
   updatedAt: z.string(),
 })
 
+export const commentFormSchema = z.object({
+  message: z
+    .string()
+    .min(1, 'Digite um comentário')
+    .max(
+      COMMENT_MESSAGE_MAX_LENGTH,
+      `O comentário deve ter no máximo ${COMMENT_MESSAGE_MAX_LENGTH} caracteres`,
+    ),
+})
+
 export type CommentSchema = z.infer<typeof commentSchema>
+export type CommentFormSchema = z.infer<typeof commentFormSchema>

--- a/apps/web/src/schemas/paginatedResponse.ts
+++ b/apps/web/src/schemas/paginatedResponse.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod'
+
+const paginationMetaSchema = z.object({
+  total: z.number(),
+  page: z.number(),
+  size: z.number(),
+  totalPages: z.number(),
+})
+
+export const paginatedResponseSchema = <T extends z.ZodTypeAny>(schema: T) =>
+  z.object({
+    data: z.array(schema),
+    meta: paginationMetaSchema,
+  })
+
+export type PaginationMetaSchema = z.infer<typeof paginationMetaSchema>


### PR DESCRIPTION
## Summary
- add a reusable paginated response schema and comment form validation helpers
- support task comment pagination and creation APIs
- refresh the task details UI with comment pagination, posting, and reactive invalidations

## Testing
- pnpm --filter @apps/web test

------
https://chatgpt.com/codex/tasks/task_e_68e6b9d9e62c832ba1cc9a3f8baf8b0f