### PR TITLE
docs: atualizar documentação de comentários

### DIFF
--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -42,3 +42,51 @@ curl -H "Authorization: Bearer $ACCESS_TOKEN" \
 ```
 
 Para renovar o token, utilize `POST /auth/refresh`. O gateway lerá o `refreshToken` do cookie e responderá com um novo `accessToken` pronto para ser enviado no header acima.
+
+## Comentários de tarefas
+
+O gateway expõe endpoints autenticados para criação e listagem paginada de comentários vinculados a uma tarefa.
+
+### Listar comentários com paginação
+
+```bash
+curl -H "Authorization: Bearer $ACCESS_TOKEN" \
+     "http://localhost:3000/tasks/<TASK_ID>/comments?page=2&limit=5"
+```
+
+Resposta (resumida):
+
+```json
+{
+  "data": [
+    {
+      "id": "f4f3...",
+      "taskId": "<TASK_ID>",
+      "authorId": "<USER_ID>",
+      "message": "Comentário mais recente",
+      "createdAt": "2024-06-01T12:34:56.000Z",
+      "updatedAt": "2024-06-01T12:34:56.000Z"
+    }
+  ],
+  "meta": {
+    "page": 2,
+    "size": 5,
+    "total": 17,
+    "totalPages": 4
+  }
+}
+```
+
+Os parâmetros `page` e `limit` são opcionais (padrões: `1` e `10`). A ordenação é decrescente por data de criação.
+
+### Criar um novo comentário
+
+```bash
+curl -X POST \
+  -H "Authorization: Bearer $ACCESS_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"message": "Comentário inicial da tarefa"}' \
+  http://localhost:3000/tasks/<TASK_ID>/comments
+```
+
+O corpo deve conter somente o campo `message` (máximo de 500 caracteres). O gateway atribui o autor com base no usuário autenticado e, ao salvar, o serviço publica `tasks.comment.created`, que o próprio gateway retransmite para os clientes WebSocket como `comment:new`.

--- a/docs/historias.md
+++ b/docs/historias.md
@@ -14,7 +14,7 @@
 * [x] Como usuário, quero **editar** uma tarefa (campos e status), para manter as informações atualizadas. — feita
 * [x] Como usuário, quero **excluir** uma tarefa, para remover itens obsoletos. — feita
 * [x] Como usuário, quero **atribuir/desatribuir** uma tarefa a **múltiplos usuários**, para distribuir o trabalho. — feita
-* [ ] Como participante da tarefa, quero **comentar** e **ver comentários** com paginação, para colaborar no contexto da tarefa. _(Observação: a API ainda não expõe endpoints de comentários; o front-end apenas consulta um endpoint inexistente.)_
+* [x] Como participante da tarefa, quero **comentar** e **ver comentários** com paginação, para colaborar no contexto da tarefa. _(Observação: o gateway agora expõe `GET /tasks/:id/comments` e `POST /tasks/:id/comments`, entregando respostas paginadas para a UI atualizar imediatamente a lista local.)_
 * [ ] Como sistema, quero **registrar histórico** (audit log) de alterações de tarefa, para rastrear quem mudou o quê e quando. _(Pendente: não há registro de audit log no serviço de tarefas.)_
 
 # Épico: Integração entre Gateway e Microserviços
@@ -33,7 +33,7 @@
 * [x] Como usuário autenticado, quero me **conectar ao WebSocket** do Gateway, para receber notificações em tempo real. — feita
 * [x] Como usuário atribuído a uma tarefa recém-criada, quero receber **`task:created`**, para ser avisado imediatamente. — feita
 * [x] Como usuário envolvido numa tarefa, quero receber **`task:updated`** quando o status mudar, para acompanhar o progresso. — feita
-* [ ] Como participante/comentado de uma tarefa, quero receber **`comment:new`**, para não perder discussões importantes. _(Observação: o gateway está pronto para propagar o evento, mas ele nunca é disparado porque não existe fluxo de criação de comentários.)_
+* [x] Como participante/comentado de uma tarefa, quero receber **`comment:new`**, para não perder discussões importantes. _(Observação: a criação de comentários agora dispara `tasks.comment.created` no serviço de tarefas, que é encaminhado pelo gateway como `comment:new`, atualizando a lista e exibindo toast no front-end.)_
 
 # Épico: Front-end (React + TanStack Router + shadcn/ui)
 


### PR DESCRIPTION
## Summary
- marca a história de comentários e o evento `comment:new` como concluídos em docs/historias.md, descrevendo os novos fluxos
- documenta no README do gateway como paginar e publicar comentários via REST, incluindo relação com o evento websocket

## Testing
- pnpm lint *(falhou: repositório apresenta inúmeros avisos/erros preexistentes nas regras `@typescript-eslint/no-unsafe-*` para vários serviços)*
- pnpm test --filter @apps/api *(sem correspondência para o filtro solicitado)*
- pnpm test --filter @apps/api-gateway
- pnpm test --filter @apps/tasks *(sem correspondência para o filtro solicitado)*
- pnpm test --filter @apps/tasks-service
- pnpm test --filter @apps/web
- pnpm build *(falhou: erros de TypeScript existentes nas builds de @apps/tasks-service e @apps/api-gateway relacionados aos DTOs de comentários e mocks de pg-mem)*

------
https://chatgpt.com/codex/tasks/task_e_68e6bd74daf4832ba404049b886a218c