### PR TITLE
fix: generalize task comment response helper

### DIFF
--- a/apps/api/src/tasks/tasks.controller.ts
+++ b/apps/api/src/tasks/tasks.controller.ts
@@ -126,8 +126,8 @@ export class TasksController {
     return this.toItemResponse(comment);
   }
 
-  private toItemResponse(task: Task): ApiResponse<Task> {
-    return { data: task };
+  private toItemResponse<T>(item: T): ApiResponse<T> {
+    return { data: item };
   }
 
   private toPaginatedResponse<T>(


### PR DESCRIPTION
## Summary
- update the reusable item response helper to accept any payload type so it can wrap comments

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e6c806a7a0832baff2dc66f2134285