### PR TITLE
fix: ajusta tipos do pg-mem nos testes

### DIFF
--- a/apps/tasks/src/testing/database.ts
+++ b/apps/tasks/src/testing/database.ts
@@ -1,14 +1,14 @@
 import { randomUUID } from 'node:crypto';
 import { DataSource, EntityTarget } from 'typeorm';
-import { newDb } from 'pg-mem';
+import { DataType, newDb } from 'pg-mem';
 
 export async function createTestDataSource(
   entities: EntityTarget<unknown>[],
 ): Promise<DataSource> {
   const db = newDb({ autoCreateForeignKeyIndices: true });
 
-  const textType = db.public.getType('text');
-  const uuidType = db.public.getType('uuid');
+  const textType = db.public.getType(DataType.text);
+  const uuidType = db.public.getType(DataType.uuid);
 
   db.public.registerFunction({
     name: 'version',


### PR DESCRIPTION
## Summary
- utiliza o enum `DataType` do pg-mem ao recuperar tipos
- corrige os erros de compilação TS2345 durante o build do serviço de tarefas

## Testing
- pnpm --filter @apps/tasks-service build

------
https://chatgpt.com/codex/tasks/task_e_68e6c9ffa8e0832b8ce27537e6aa1899