### PR TITLE
fix: allow generic item responses in tasks controller

### DIFF
--- a/apps/api/src/tasks/tasks.controller.ts
+++ b/apps/api/src/tasks/tasks.controller.ts
@@ -126,8 +126,8 @@ export class TasksController {
     return this.toItemResponse(comment);
   }
 
-  private toItemResponse(task: Task): ApiResponse<Task> {
-    return { data: task };
+  private toItemResponse<T>(item: T): ApiResponse<T> {
+    return { data: item };
   }
 
   private toPaginatedResponse<T>(


### PR DESCRIPTION
## Summary
- make the tasks controller item response helper generic so it can wrap different DTO types

## Testing
- pnpm --filter @apps/api-gateway build

------
https://chatgpt.com/codex/tasks/task_e_68e6ca118d88832badea585bbd56695d