### PR TITLE
feat: add task audit log modeling

### DIFF
--- a/apps/tasks/src/tasks/task-audit-log.entity.ts
+++ b/apps/tasks/src/tasks/task-audit-log.entity.ts
@@ -1,0 +1,34 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import type { TaskAuditLogChangeDTO } from '@repo/types';
+
+@Entity({ name: 'task_audit_logs' })
+export class TaskAuditLog {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'uuid' })
+  taskId: string;
+
+  @Column({ type: 'varchar', length: 255 })
+  action: string;
+
+  @Column({ type: 'varchar', length: 255, nullable: true })
+  actorId?: string | null;
+
+  @Column({ type: 'varchar', length: 255, nullable: true })
+  actorDisplayName?: string | null;
+
+  @Column({ type: 'jsonb', nullable: true, default: () => "'[]'::jsonb" })
+  changes?: TaskAuditLogChangeDTO[] | null;
+
+  @Column({ type: 'jsonb', nullable: true, default: () => "'{}'::jsonb" })
+  metadata?: Record<string, unknown> | null;
+
+  @CreateDateColumn({ type: 'timestamptz' })
+  createdAt: Date;
+}

--- a/apps/tasks/src/tasks/tasks.module.ts
+++ b/apps/tasks/src/tasks/tasks.module.ts
@@ -3,6 +3,7 @@ import { ConfigModule, ConfigService } from '@nestjs/config';
 import { ClientsModule, Transport } from '@nestjs/microservices';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Task } from './task.entity';
+import { TaskAuditLog } from './task-audit-log.entity';
 import { TasksService } from './tasks.service';
 import { TasksController } from './tasks.controller';
 import { TASKS_EVENTS_CLIENT, TASKS_EVENTS_QUEUE } from './tasks.constants';
@@ -12,7 +13,7 @@ import { CommentsController } from '../comments/comments.controller';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Task, Comment]),
+    TypeOrmModule.forFeature([Task, Comment, TaskAuditLog]),
     ConfigModule,
     ClientsModule.registerAsync([
       {

--- a/packages/types/src/contracts/events/tasks.ts
+++ b/packages/types/src/contracts/events/tasks.ts
@@ -1,5 +1,9 @@
 import type { CommentDTO } from "../../dto/comment.js";
 import type { TaskDTO } from "../../dto/task.js";
+import type {
+  TaskAuditLogActorDTO,
+  TaskAuditLogChangeDTO,
+} from "../../dto/task-audit-log.js";
 
 export const TASK_EVENT_PATTERNS = {
   CREATED: "task.created",
@@ -13,7 +17,8 @@ export type TaskEventPattern =
 export interface TaskEventPayload {
   task: TaskDTO;
   recipients?: string[];
-  changes?: Record<string, unknown>;
+  actor?: TaskAuditLogActorDTO | null;
+  changes?: TaskAuditLogChangeDTO[] | Record<string, unknown> | null;
 }
 
 export const TASK_FORWARDING_PATTERNS = {
@@ -32,5 +37,6 @@ export interface TaskCommentCreatedPayload {
 export interface TaskUpdatedForwardPayload {
   task: TaskDTO | { id: string; [key: string]: unknown };
   recipients: string[];
-  changes?: Record<string, unknown>;
+  actor?: TaskAuditLogActorDTO | null;
+  changes?: TaskAuditLogChangeDTO[] | Record<string, unknown> | null;
 }

--- a/packages/types/src/contracts/rpc/tasks.ts
+++ b/packages/types/src/contracts/rpc/tasks.ts
@@ -11,6 +11,10 @@ import type {
   TaskListFiltersDTO,
   UpdateTaskDTO,
 } from "../../dto/task.js";
+import type {
+  PaginatedTaskAuditLogsDTO,
+  TaskAuditLogListFiltersDTO,
+} from "../../dto/task-audit-log.js";
 
 export const TASKS_MESSAGE_PATTERNS = {
   CREATE: "tasks.create",
@@ -20,6 +24,7 @@ export const TASKS_MESSAGE_PATTERNS = {
   REMOVE: "tasks.remove",
   COMMENT_CREATE: "tasks.comment.create",
   COMMENT_FIND_ALL: "tasks.comment.findAll",
+  AUDIT_FIND_ALL: "tasks.audit.findAll",
 } as const;
 
 export type TasksMessagePattern =
@@ -53,6 +58,9 @@ export type TasksCommentsCreateResult = CommentDTO;
 export type TasksCommentsFindAllPayload = TaskCommentListFiltersDTO;
 export type TasksCommentsFindAllResult = PaginatedCommentsDTO;
 
+export type TasksAuditFindAllPayload = TaskAuditLogListFiltersDTO;
+export type TasksAuditFindAllResult = PaginatedTaskAuditLogsDTO;
+
 export interface TasksRpcContractMap {
   [TASKS_MESSAGE_PATTERNS.CREATE]: {
     payload: TasksCreatePayload;
@@ -81,5 +89,9 @@ export interface TasksRpcContractMap {
   [TASKS_MESSAGE_PATTERNS.COMMENT_FIND_ALL]: {
     payload: TasksCommentsFindAllPayload;
     response: TasksCommentsFindAllResult;
+  };
+  [TASKS_MESSAGE_PATTERNS.AUDIT_FIND_ALL]: {
+    payload: TasksAuditFindAllPayload;
+    response: TasksAuditFindAllResult;
   };
 }

--- a/packages/types/src/dto/index.ts
+++ b/packages/types/src/dto/index.ts
@@ -1,5 +1,6 @@
 export * from "./auth.js";
 export * from "./task.js";
+export * from "./task-audit-log.js";
 export * from "./comment.js";
 export type * from "./notification.js";
 export type * from "./tokens.js";

--- a/packages/types/src/dto/task-audit-log.ts
+++ b/packages/types/src/dto/task-audit-log.ts
@@ -1,0 +1,167 @@
+import { Type } from "class-transformer";
+import {
+  Allow,
+  IsArray,
+  IsDateString,
+  IsInt,
+  IsNotEmpty,
+  IsObject,
+  IsOptional,
+  IsString,
+  IsUUID,
+  Min,
+  ValidateIf,
+  ValidateNested,
+} from "class-validator";
+
+export interface TaskAuditLogActorDTO {
+  id: string;
+  displayName?: string | null;
+}
+
+export interface TaskAuditLogChangeDTO {
+  field: string;
+  previousValue?: unknown;
+  currentValue?: unknown;
+}
+
+export interface TaskAuditLogDTO {
+  id: string;
+  taskId: string;
+  action: string;
+  actorId?: string | null;
+  actorDisplayName?: string | null;
+  actor?: TaskAuditLogActorDTO | null;
+  changes?: TaskAuditLogChangeDTO[] | null;
+  metadata?: Record<string, unknown> | null;
+  createdAt: string;
+}
+
+export interface TaskAuditLogListFiltersDTO {
+  taskId: string;
+  page?: number;
+  limit?: number;
+}
+
+export interface PaginatedTaskAuditLogsDTO {
+  data: TaskAuditLogDTO[];
+  total: number;
+  page: number;
+  limit: number;
+}
+
+export class TaskAuditLogActorDto implements TaskAuditLogActorDTO {
+  @IsUUID()
+  @IsNotEmpty()
+  id!: string;
+
+  @IsOptional()
+  @ValidateIf((_, value) => value !== null)
+  @IsString()
+  displayName?: string | null;
+}
+
+export class TaskAuditLogChangeDto implements TaskAuditLogChangeDTO {
+  @IsString()
+  @IsNotEmpty()
+  field!: string;
+
+  @IsOptional()
+  @Allow()
+  previousValue?: unknown;
+
+  @IsOptional()
+  @Allow()
+  currentValue?: unknown;
+}
+
+export class TaskAuditLogDto implements TaskAuditLogDTO {
+  @IsUUID()
+  @IsNotEmpty()
+  id!: string;
+
+  @IsUUID()
+  @IsNotEmpty()
+  taskId!: string;
+
+  @IsString()
+  @IsNotEmpty()
+  action!: string;
+
+  @IsOptional()
+  @ValidateIf((_, value) => value !== null)
+  @IsUUID()
+  actorId?: string | null;
+
+  @IsOptional()
+  @ValidateIf((_, value) => value !== null)
+  @IsString()
+  actorDisplayName?: string | null;
+
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => TaskAuditLogActorDto)
+  actor?: TaskAuditLogActorDto | null;
+
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => TaskAuditLogChangeDto)
+  changes?: TaskAuditLogChangeDto[] | null;
+
+  @IsOptional()
+  @ValidateIf((_, value) => value !== null)
+  @IsObject()
+  metadata?: Record<string, unknown> | null;
+
+  @IsDateString()
+  createdAt!: string;
+}
+
+export class ListTaskAuditLogsDto implements TaskAuditLogListFiltersDTO {
+  @IsUUID()
+  @IsNotEmpty()
+  taskId!: string;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  limit?: number;
+}
+
+export class ListTaskAuditLogsQueryDto {
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  limit?: number;
+}
+
+export class PaginatedTaskAuditLogsDto implements PaginatedTaskAuditLogsDTO {
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => TaskAuditLogDto)
+  data!: TaskAuditLogDto[];
+
+  @IsInt()
+  total!: number;
+
+  @IsInt()
+  page!: number;
+
+  @IsInt()
+  limit!: number;
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -8,6 +8,7 @@ export * from "./enums/auth.js";
 export * from "./contracts/rpc/tasks.js";
 export * from "./contracts/events/tasks.js";
 export * from "./dto/task.js";
+export * from "./dto/task-audit-log.js";
 export * from "./enums/task.js";
 
 // Notifications


### PR DESCRIPTION
## Summary
- add a TaskAuditLog TypeORM entity and register it in the tasks module so the table is created automatically
- introduce audit log DTOs, validators, and RPC patterns in @repo/types for listing support
- extend task event payloads to surface actor context and structured change details

## Testing
- pnpm --filter @repo/types lint *(fails: existing warnings inside generated dist-cjs files trigger the max-warnings=0 rule)*

------
https://chatgpt.com/codex/tasks/task_e_68e6d26549dc832bbef0b93cd53d72f8