### PR TITLE
feat: add audit logging to task service

### DIFF
--- a/apps/tasks/src/tasks/task-audit-logs.service.ts
+++ b/apps/tasks/src/tasks/task-audit-logs.service.ts
@@ -1,0 +1,39 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import type {
+  TaskAuditLogActorDTO,
+  TaskAuditLogChangeDTO,
+} from '@repo/types';
+import { TaskAuditLog } from './task-audit-log.entity';
+
+export interface CreateTaskAuditLogInput {
+  taskId: string;
+  action: string;
+  actor?: TaskAuditLogActorDTO | null;
+  changes?: TaskAuditLogChangeDTO[] | null;
+  metadata?: Record<string, unknown> | null;
+}
+
+@Injectable()
+export class TaskAuditLogsService {
+  constructor(
+    @InjectRepository(TaskAuditLog)
+    private readonly repository: Repository<TaskAuditLog>,
+  ) {}
+
+  async createLog(input: CreateTaskAuditLogInput): Promise<TaskAuditLog> {
+    const { taskId, action, actor, changes, metadata } = input;
+
+    const log = this.repository.create({
+      taskId,
+      action,
+      actorId: actor?.id ?? null,
+      actorDisplayName: actor?.displayName ?? null,
+      changes: changes && changes.length > 0 ? changes : null,
+      metadata: metadata ?? null,
+    });
+
+    return this.repository.save(log);
+  }
+}

--- a/apps/tasks/src/tasks/task-diff.util.ts
+++ b/apps/tasks/src/tasks/task-diff.util.ts
@@ -1,0 +1,100 @@
+import { isDeepStrictEqual } from 'node:util';
+import type {
+  TaskAuditLogChangeDTO,
+  TaskAssigneeDTO,
+  TaskPriority,
+  TaskStatus,
+} from '@repo/types';
+import type { Task } from './task.entity';
+
+export type TaskState = Pick<
+  Task,
+  'title' | 'description' | 'status' | 'priority' | 'dueDate' | 'assignees'
+>;
+
+export function createTaskStateSnapshot(task: Task): TaskState {
+  return {
+    title: task.title,
+    description: task.description ?? null,
+    status: task.status as TaskStatus,
+    priority: task.priority as TaskPriority,
+    dueDate: task.dueDate ? new Date(task.dueDate) : null,
+    assignees: Array.isArray(task.assignees)
+      ? task.assignees.map((assignee) => ({ ...assignee }))
+      : [],
+  };
+}
+
+export function diffTaskChanges(
+  previous: TaskState,
+  current: TaskState,
+): TaskAuditLogChangeDTO[] {
+  const fields: (keyof TaskState)[] = [
+    'title',
+    'description',
+    'status',
+    'priority',
+    'dueDate',
+    'assignees',
+  ];
+
+  const changes: TaskAuditLogChangeDTO[] = [];
+
+  for (const field of fields) {
+    const previousValue = normalizeFieldValue(field, previous[field]);
+    const currentValue = normalizeFieldValue(field, current[field]);
+
+    if (isDeepStrictEqual(previousValue, currentValue)) {
+      continue;
+    }
+
+    changes.push({
+      field,
+      previousValue,
+      currentValue,
+    });
+  }
+
+  return changes;
+}
+
+type TaskField = keyof TaskState;
+
+type NormalizedFieldValue =
+  | string
+  | null
+  | TaskAssigneeDTO[]
+  | TaskStatus
+  | TaskPriority;
+
+function normalizeFieldValue(
+  field: TaskField,
+  value: TaskState[TaskField],
+): NormalizedFieldValue {
+  if (value === undefined || value === null) {
+    return field === 'assignees' ? [] : null;
+  }
+
+  switch (field) {
+    case 'dueDate':
+      return value instanceof Date ? value.toISOString() : new Date(value).toISOString();
+    case 'assignees':
+      if (!Array.isArray(value)) {
+        return [];
+      }
+
+      return value
+        .map((assignee) => ({
+          id: assignee.id,
+          username: assignee.username,
+        }))
+        .sort((a, b) => a.id.localeCompare(b.id));
+    case 'status':
+    case 'priority':
+      return value as TaskStatus | TaskPriority;
+    case 'title':
+    case 'description':
+    default:
+      return typeof value === 'string' ? value : String(value);
+  }
+}

--- a/apps/tasks/src/tasks/tasks.controller.ts
+++ b/apps/tasks/src/tasks/tasks.controller.ts
@@ -18,11 +18,11 @@ export class TasksController {
   @MessagePattern(TASKS_MESSAGE_PATTERNS.CREATE)
   async create(@Payload() payload: unknown) {
     try {
-      const { actor: _actor, ...data } = transformPayload(
+      const { actor, ...data } = transformPayload(
         CreateTaskPayloadDto,
         payload,
       );
-      return await this.tasksService.create(data);
+      return await this.tasksService.create(data, actor ?? null);
     } catch (error) {
       throw toRpcException(error);
     }
@@ -51,8 +51,11 @@ export class TasksController {
   @MessagePattern(TASKS_MESSAGE_PATTERNS.UPDATE)
   async update(@Payload() payload: unknown) {
     try {
-      const { id, data } = transformPayload(UpdateTaskPayloadDto, payload);
-      return await this.tasksService.update(id, data);
+      const { id, data, actor } = transformPayload(
+        UpdateTaskPayloadDto,
+        payload,
+      );
+      return await this.tasksService.update(id, data, actor ?? null);
     } catch (error) {
       throw toRpcException(error);
     }
@@ -61,8 +64,8 @@ export class TasksController {
   @MessagePattern(TASKS_MESSAGE_PATTERNS.REMOVE)
   async remove(@Payload() payload: unknown) {
     try {
-      const { id } = transformPayload(RemoveTaskPayloadDto, payload);
-      return await this.tasksService.remove(id);
+      const { id, actor } = transformPayload(RemoveTaskPayloadDto, payload);
+      return await this.tasksService.remove(id, actor ?? null);
     } catch (error) {
       throw toRpcException(error);
     }

--- a/apps/tasks/src/tasks/tasks.module.ts
+++ b/apps/tasks/src/tasks/tasks.module.ts
@@ -10,6 +10,7 @@ import { TASKS_EVENTS_CLIENT, TASKS_EVENTS_QUEUE } from './tasks.constants';
 import { Comment } from '../comments/comment.entity';
 import { CommentsService } from '../comments/comments.service';
 import { CommentsController } from '../comments/comments.controller';
+import { TaskAuditLogsService } from './task-audit-logs.service';
 
 @Module({
   imports: [
@@ -39,7 +40,7 @@ import { CommentsController } from '../comments/comments.controller';
     ]),
   ],
   controllers: [TasksController, CommentsController],
-  providers: [TasksService, CommentsService],
+  providers: [TasksService, CommentsService, TaskAuditLogsService],
   exports: [TypeOrmModule, TasksService],
 })
 export class TasksModule {}

--- a/apps/web/src/features/tasks/pages/TasksPage.tsx
+++ b/apps/web/src/features/tasks/pages/TasksPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef } from 'react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
-import type { CommentDTO, Task } from '@repo/types'
+import type { CommentDTO, Task, TaskEventPayload } from '@repo/types'
 
 import { Button } from '@/components/ui/button'
 import { toast } from '@/components/ui/use-toast'
@@ -70,12 +70,25 @@ export function TasksPage() {
         ? 'Não foi possível carregar as tarefas. Tente novamente.'
         : null
 
+  const isTaskEventPayload = (
+    payload: Task | TaskEventPayload,
+  ): payload is TaskEventPayload =>
+    typeof payload === 'object' && payload !== null && 'task' in payload
+
   useEffect(() => {
-    const handleTaskCreated = () => {
+    const handleTaskCreated = (_payload?: TaskEventPayload) => {
       void queryClient.invalidateQueries({ queryKey: ['tasks'] })
     }
 
-    const handleTaskUpdated = (updatedTask: Task) => {
+    const handleTaskUpdated = (payload: Task | TaskEventPayload) => {
+      const updatedTask = isTaskEventPayload(payload)
+        ? payload.task
+        : payload
+
+      if (!updatedTask) {
+        return
+      }
+
       queryClient.setQueriesData<Task[] | undefined>(
         { queryKey: ['tasks'] },
         (oldTasks) => {


### PR DESCRIPTION
## Summary
- add a dedicated TaskAuditLogsService and diff utility to capture task changes
- record audit entries and enrich task mutation events with actor/change metadata
- adjust consumers and tests to pass actor data and handle the new event payload structure

## Testing
- pnpm --filter @apps/tasks-service test -- tasks/tasks.service.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68e6f6b8ec08832b930c4fcf515dfd59