### PR TITLE
feat: add task audit log retrieval endpoints

### DIFF
--- a/apps/api/src/tasks/tasks.controller.ts
+++ b/apps/api/src/tasks/tasks.controller.ts
@@ -20,17 +20,22 @@ import {
   CreateCommentBodyDto,
   CreateTaskDto,
   ListTaskCommentsQueryDto,
+  ListTaskAuditLogsQueryDto,
   ListTasksQueryDto,
   TaskIdParamDto,
   UpdateTaskDto,
   type ApiResponse,
   type PaginatedResponse,
   type Comment,
+  type TaskAuditLog,
   type Task,
   type TaskActor,
 } from '@repo/types';
 import { TasksService } from './tasks.service';
-import type { ListTaskCommentsFilters } from './tasks.service';
+import type {
+  ListTaskAuditLogsFilters,
+  ListTaskCommentsFilters,
+} from './tasks.service';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { CurrentUser, type CurrentUserPayload } from '../auth/current-user.decorator';
 
@@ -126,6 +131,24 @@ export class TasksController {
     const result = await this.tasksService.listComments(params.id, filters);
 
     return this.toPaginatedResponse<Comment>(result);
+  }
+
+  @Get(':id/audit-log')
+  @ApiOkResponse({
+    description: 'List audit logs for a task with pagination',
+  })
+  async listAuditLogs(
+    @Param() params: TaskIdParamDto,
+    @Query() query: ListTaskAuditLogsQueryDto,
+  ): Promise<PaginatedResponse<TaskAuditLog>> {
+    const filters: ListTaskAuditLogsFilters = {
+      page: query.page ?? 1,
+      limit: query.limit ?? 10,
+    };
+
+    const result = await this.tasksService.listAuditLogs(params.id, filters);
+
+    return this.toPaginatedResponse<TaskAuditLog>(result);
   }
 
   @Post(':id/comments')

--- a/apps/api/src/tasks/tasks.service.ts
+++ b/apps/api/src/tasks/tasks.service.ts
@@ -17,10 +17,12 @@ import type {
   CreateComment,
   CreateTask,
   PaginatedComments as PaginatedCommentsResult,
+  PaginatedTaskAuditLogsDTO as PaginatedTaskAuditLogsResult,
   PaginatedTasks as PaginatedTasksResult,
   Task,
   TaskActor,
   TaskCommentListFilters,
+  TaskAuditLogListFiltersDTO,
   TaskListFilters,
   TasksCreatePayload,
   TasksMessagePattern,
@@ -36,6 +38,11 @@ export type PaginatedTasks = PaginatedTasksResult;
 export type PaginatedComments = PaginatedCommentsResult;
 export type ListTaskCommentsFilters = Omit<TaskCommentListFilters, 'taskId'>;
 export type CreateTaskComment = Omit<CreateComment, 'taskId'>;
+export type PaginatedTaskAuditLogs = PaginatedTaskAuditLogsResult;
+export type ListTaskAuditLogsFilters = Omit<
+  TaskAuditLogListFiltersDTO,
+  'taskId'
+>;
 
 @Injectable()
 export class TasksService {
@@ -105,6 +112,19 @@ export class TasksService {
       taskId,
       ...data,
     });
+  }
+
+  async listAuditLogs(
+    taskId: string,
+    filters: ListTaskAuditLogsFilters = {},
+  ): Promise<PaginatedTaskAuditLogs> {
+    return this.send<PaginatedTaskAuditLogs>(
+      TASKS_MESSAGE_PATTERNS.AUDIT_FIND_ALL,
+      {
+        taskId,
+        ...filters,
+      },
+    );
   }
 
   private async send<TResponse>(

--- a/apps/tasks/src/tasks/task-audit-logs.service.ts
+++ b/apps/tasks/src/tasks/task-audit-logs.service.ts
@@ -2,8 +2,11 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import type {
+  PaginatedTaskAuditLogsDTO,
   TaskAuditLogActorDTO,
   TaskAuditLogChangeDTO,
+  TaskAuditLogDTO,
+  TaskAuditLogListFiltersDTO,
 } from '@repo/types';
 import { TaskAuditLog } from './task-audit-log.entity';
 
@@ -35,5 +38,47 @@ export class TaskAuditLogsService {
     });
 
     return this.repository.save(log);
+  }
+
+  async findAll(
+    filters: TaskAuditLogListFiltersDTO,
+  ): Promise<PaginatedTaskAuditLogsDTO> {
+    const page = filters.page && filters.page > 0 ? filters.page : 1;
+    const limit = filters.limit && filters.limit > 0 ? filters.limit : 10;
+
+    const [logs, total] = await this.repository.findAndCount({
+      where: { taskId: filters.taskId },
+      order: { createdAt: 'DESC' },
+      take: limit,
+      skip: (page - 1) * limit,
+    });
+
+    const data = logs.map((log) => this.toDto(log));
+
+    return {
+      data,
+      total,
+      page,
+      limit,
+    };
+  }
+
+  private toDto(log: TaskAuditLog): TaskAuditLogDTO {
+    return {
+      id: log.id,
+      taskId: log.taskId,
+      action: log.action,
+      actorId: log.actorId ?? null,
+      actorDisplayName: log.actorDisplayName ?? null,
+      actor: log.actorId
+        ? {
+            id: log.actorId,
+            displayName: log.actorDisplayName ?? null,
+          }
+        : null,
+      changes: log.changes ?? null,
+      metadata: log.metadata ?? null,
+      createdAt: log.createdAt.toISOString(),
+    };
   }
 }

--- a/apps/tasks/src/tasks/tasks.controller.ts
+++ b/apps/tasks/src/tasks/tasks.controller.ts
@@ -3,6 +3,7 @@ import { MessagePattern, Payload } from '@nestjs/microservices';
 import { TasksService, PaginatedTasks } from './tasks.service';
 import {
   CreateTaskPayloadDto,
+  ListTaskAuditLogsDto,
   ListTasksDto,
   RemoveTaskPayloadDto,
   TaskIdDto,
@@ -66,6 +67,16 @@ export class TasksController {
     try {
       const { id, actor } = transformPayload(RemoveTaskPayloadDto, payload);
       return await this.tasksService.remove(id, actor ?? null);
+    } catch (error) {
+      throw toRpcException(error);
+    }
+  }
+
+  @MessagePattern(TASKS_MESSAGE_PATTERNS.AUDIT_FIND_ALL)
+  async findAuditLogs(@Payload() payload: unknown) {
+    try {
+      const dto = transformPayload(ListTaskAuditLogsDto, payload);
+      return await this.tasksService.findAuditLogs(dto);
     } catch (error) {
       throw toRpcException(error);
     }

--- a/apps/tasks/src/tasks/tasks.service.ts
+++ b/apps/tasks/src/tasks/tasks.service.ts
@@ -19,7 +19,9 @@ import {
 } from '@repo/types/utils/datetime';
 import type {
   CreateTaskDTO,
+  PaginatedTaskAuditLogsDTO,
   TaskEventPattern,
+  TaskAuditLogListFiltersDTO,
   TaskListFiltersDTO,
   UpdateTaskDTO,
 } from '@repo/types';
@@ -137,6 +139,12 @@ export class TasksService {
     }
 
     return task;
+  }
+
+  async findAuditLogs(
+    filters: TaskAuditLogListFiltersDTO,
+  ): Promise<PaginatedTaskAuditLogsDTO> {
+    return this.auditLogsService.findAll(filters);
   }
 
   async update(


### PR DESCRIPTION
## Summary
- add pagination support for task audit logs inside the tasks microservice and expose an RPC handler
- map audit log entities to DTOs including actor metadata before returning them
- expose a REST endpoint in the API gateway to fetch paginated task audit logs via the TasksService

## Testing
- pnpm --filter tasks test -- --runInBand *(no projects matched the filters)*

------
https://chatgpt.com/codex/tasks/task_e_68e6f9a69f54832b8e7444798aeab6d8