### PR TITLE
Fix tasks service tsconfig paths and typing

### DIFF
--- a/apps/tasks/src/comments/comments.service.ts
+++ b/apps/tasks/src/comments/comments.service.ts
@@ -2,7 +2,7 @@ import { Inject, Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { ClientProxy } from '@nestjs/microservices';
 import { defaultIfEmpty, lastValueFrom } from 'rxjs';
-import { Repository } from 'typeorm';
+import { Repository, type DeepPartial } from 'typeorm';
 import { Comment } from './comment.entity';
 import { Task } from '../tasks/task.entity';
 import { TASKS_EVENTS_CLIENT } from '../tasks/tasks.constants';
@@ -16,9 +16,7 @@ import {
   type TaskForwardingPattern,
 } from '@repo/types';
 
-export interface PaginatedComments extends PaginatedCommentsDTO {
-  data: CommentDTO[];
-}
+export type PaginatedComments = PaginatedCommentsDTO;
 
 @Injectable()
 export class CommentsService {
@@ -40,8 +38,8 @@ export class CommentsService {
     const comment = this.commentsRepository.create({
       ...dto,
       authorName: normalizedAuthorName ? normalizedAuthorName : null,
-    });
-    const saved = await this.commentsRepository.save(comment);
+    } as DeepPartial<Comment>);
+    const saved = await this.commentsRepository.save<Comment>(comment);
 
     await this.emitCommentCreated(saved, task);
 

--- a/apps/tasks/src/common/rpc.utils.ts
+++ b/apps/tasks/src/common/rpc.utils.ts
@@ -1,10 +1,14 @@
 import { BadRequestException, HttpException } from '@nestjs/common';
 import { RpcException } from '@nestjs/microservices';
 import { plainToInstance } from 'class-transformer';
+import type { ClassConstructor } from 'class-transformer';
 import { validateSync } from 'class-validator';
 
-export function transformPayload<T>(cls: new () => T, payload: unknown): T {
-  const dto = plainToInstance(cls, payload, {
+export function transformPayload<T extends ClassConstructor<object>>(
+  cls: T,
+  payload: unknown,
+): InstanceType<T> {
+  const dto = plainToInstance(cls, payload as object, {
     enableImplicitConversion: true,
     exposeDefaultValues: true,
   });
@@ -19,7 +23,7 @@ export function transformPayload<T>(cls: new () => T, payload: unknown): T {
     throw new BadRequestException(errors);
   }
 
-  return dto;
+  return dto as InstanceType<T>;
 }
 
 export function toRpcException(error: unknown): RpcException {

--- a/apps/tasks/src/tasks/tasks.service.ts
+++ b/apps/tasks/src/tasks/tasks.service.ts
@@ -2,7 +2,7 @@ import { Inject, Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { ClientProxy } from '@nestjs/microservices';
 import { defaultIfEmpty, lastValueFrom } from 'rxjs';
-import { Repository } from 'typeorm';
+import { Repository, type DeepPartial } from 'typeorm';
 import { Task } from './task.entity';
 import { TASKS_EVENTS_CLIENT } from './tasks.constants';
 import {
@@ -56,9 +56,9 @@ export class TasksService {
       dueDate: dto.dueDate
         ? parseDateInTimezone(dto.dueDate, this.taskTimezone)
         : null,
-    });
+    } as DeepPartial<Task>);
 
-    const saved = await this.tasksRepository.save(task);
+    const saved = await this.tasksRepository.save<Task>(task);
 
     const auditActor = this.toAuditLogActor(actor);
 

--- a/apps/tasks/tsconfig.build.json
+++ b/apps/tasks/tsconfig.build.json
@@ -2,8 +2,14 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "paths": {
-      "@repo/types": ["../../packages/types/dist/index.d.ts"],
-      "@repo/types/*": ["../../packages/types/dist/*.d.ts"]
+      "@repo/types": [
+        "../../packages/types/dist-cjs/index.js",
+        "../../packages/types/dist/index.d.ts"
+      ],
+      "@repo/types/*": [
+        "../../packages/types/dist-cjs/*.js",
+        "../../packages/types/dist/*.d.ts"
+      ]
     }
   },
   "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]


### PR DESCRIPTION
## Summary
- align the tasks service build tsconfig path aliases with the runtime configuration so both JS and declaration outputs are resolved
- tighten transformPayload typing so Nest DTO constructors infer the correct instance types during validation
- ensure repository create/save usage is typed with DeepPartial to preserve entity types during persistence

## Testing
- `pnpm exec tsc -p apps/tasks/tsconfig.build.json`
- `pnpm turbo dev --filter @apps/tasks-service`


------
https://chatgpt.com/codex/tasks/task_e_68e7017d2a78832baa529f50c7b185c7