### PR TITLE
Normalize task dates in event payload

### DIFF
--- a/apps/tasks/src/tasks/tasks.service.ts
+++ b/apps/tasks/src/tasks/tasks.service.ts
@@ -10,6 +10,7 @@ import {
   type TaskActor,
   type TaskAuditLogActorDTO,
   type TaskAuditLogChangeDTO,
+  type TaskDTO,
   type TaskEventPayload,
 } from '@repo/types';
 import {
@@ -253,7 +254,7 @@ export class TasksService {
     changes?: TaskAuditLogChangeDTO[] | null,
   ): TaskEventPayload {
     const payload: TaskEventPayload = {
-      task,
+      task: this.toTaskDto(task),
     };
 
     if (actor) {
@@ -265,5 +266,14 @@ export class TasksService {
     }
 
     return payload;
+  }
+
+  private toTaskDto(task: Task): TaskDTO {
+    return {
+      ...task,
+      dueDate: task.dueDate ? task.dueDate.toISOString() : null,
+      createdAt: task.createdAt.toISOString(),
+      updatedAt: task.updatedAt.toISOString(),
+    };
   }
 }


### PR DESCRIPTION
## Summary
- add a helper to convert Task entities into TaskDTO objects with ISO date strings
- ensure task event payloads reuse the new helper when emitting events

## Testing
- pnpm tsc -p apps/tasks/tsconfig.build.json
- pnpm turbo dev --filter @apps/tasks-service


------
https://chatgpt.com/codex/tasks/task_e_68e704ed5148832b893bbea6c390536f