### PR TITLE
Atualiza getTasks para resposta paginada

### DIFF
--- a/apps/web/src/features/tasks/api/getTasks.test.ts
+++ b/apps/web/src/features/tasks/api/getTasks.test.ts
@@ -1,0 +1,79 @@
+import 'reflect-metadata'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  TaskPriority,
+  TaskStatus,
+  type PaginatedResponse,
+  type Task,
+} from '@repo/types'
+
+import { getTasks } from './getTasks'
+
+const fetchWithAuthMock = vi.hoisted(() => vi.fn()) as ReturnType<typeof vi.fn>
+
+vi.mock('@/lib/apiClient', () => ({
+  fetchWithAuth: fetchWithAuthMock,
+  API_BASE_URL: '',
+}))
+
+describe('getTasks', () => {
+  beforeEach(() => {
+    fetchWithAuthMock.mockReset()
+  })
+
+  it('retorna os dados paginados com meta', async () => {
+    const apiResponse: PaginatedResponse<Task> = {
+      data: [
+        {
+          id: '1',
+          title: 'Tarefa de teste',
+          description: 'Descrição',
+          status: TaskStatus.TODO,
+          priority: TaskPriority.MEDIUM,
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+          dueDate: null,
+          assignees: [],
+        },
+      ],
+      meta: {
+        page: 1,
+        size: 10,
+        total: 1,
+        totalPages: 1,
+      },
+    }
+
+    fetchWithAuthMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: vi.fn().mockResolvedValue(apiResponse),
+    })
+
+    const result = await getTasks()
+
+    expect(result).toEqual(apiResponse)
+    expect(fetchWithAuthMock).toHaveBeenCalledWith('/api/tasks', {
+      method: 'GET',
+    })
+  })
+
+  it('propaga os filtros de paginação na URL', async () => {
+    fetchWithAuthMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: vi.fn().mockResolvedValue({
+        data: [],
+        meta: { page: 2, size: 5, total: 0, totalPages: 0 },
+      }),
+    })
+
+    await getTasks({ page: 2, size: 5 })
+
+    expect(fetchWithAuthMock).toHaveBeenCalledWith('/api/tasks?page=2&size=5', {
+      method: 'GET',
+    })
+  })
+})

--- a/apps/web/src/features/tasks/api/getTasks.ts
+++ b/apps/web/src/features/tasks/api/getTasks.ts
@@ -1,25 +1,33 @@
-import type { Task, TaskPriority, TaskStatus } from '@repo/types'
-import { z } from 'zod'
+import type { PaginatedResponse, Task, TaskPriority, TaskStatus } from '@repo/types'
 
 import { API_BASE_URL, fetchWithAuth } from '@/lib/apiClient'
+import { paginatedResponseSchema } from '@/schemas/paginatedResponse'
 
 import { taskSchema } from '../schemas/taskSchema'
 
 const TASKS_ENDPOINT = API_BASE_URL ? `${API_BASE_URL}/tasks` : '/api/tasks'
 
-const paginatedTasksSchema = z.object({
-  data: taskSchema.array(),
-})
+const paginatedTasksSchema = paginatedResponseSchema(taskSchema)
 
 interface GetTasksFilters {
   status?: TaskStatus | 'ALL'
   priority?: TaskPriority | 'ALL'
   searchTerm?: string | null
   dueDate?: string | null
+  page?: number
+  size?: number
 }
 
 function buildTasksUrl(filters?: GetTasksFilters) {
   const params = new URLSearchParams()
+
+  if (filters?.page) {
+    params.set('page', filters.page.toString())
+  }
+
+  if (filters?.size) {
+    params.set('size', filters.size.toString())
+  }
 
   if (filters?.status && filters.status !== 'ALL') {
     params.set('status', filters.status)
@@ -43,7 +51,9 @@ function buildTasksUrl(filters?: GetTasksFilters) {
   return query ? `${TASKS_ENDPOINT}?${query}` : TASKS_ENDPOINT
 }
 
-export async function getTasks(filters?: GetTasksFilters): Promise<Task[]> {
+export async function getTasks(
+  filters?: GetTasksFilters,
+): Promise<PaginatedResponse<Task>> {
   const response = await fetchWithAuth(buildTasksUrl(filters), {
     method: 'GET',
   })
@@ -57,7 +67,7 @@ export async function getTasks(filters?: GetTasksFilters): Promise<Task[]> {
   const data = await response.json()
   const parsed = paginatedTasksSchema.parse(data)
 
-  return parsed.data
+  return parsed
 }
 
 export type { GetTasksFilters }

--- a/apps/web/src/features/tasks/pages/TasksPage.tsx
+++ b/apps/web/src/features/tasks/pages/TasksPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef } from 'react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
-import type { CommentDTO, Task, TaskEventPayload } from '@repo/types'
+import type { CommentDTO, PaginatedResponse, Task, TaskEventPayload } from '@repo/types'
 
 import { Button } from '@/components/ui/button'
 import { toast } from '@/components/ui/use-toast'
@@ -48,7 +48,7 @@ export function TasksPage() {
     queryFn: () => getTasks(filters),
   })
 
-  const tasks = tasksQuery.data ?? []
+  const tasks = tasksQuery.data?.data ?? []
   const isPending = tasksQuery.isPending
   const isFetching = tasksQuery.isFetching
   const isLoading = isPending || (isFetching && tasks.length === 0)
@@ -89,16 +89,19 @@ export function TasksPage() {
         return
       }
 
-      queryClient.setQueriesData<Task[] | undefined>(
+      queryClient.setQueriesData<PaginatedResponse<Task> | undefined>(
         { queryKey: ['tasks'] },
         (oldTasks) => {
           if (!oldTasks) {
             return oldTasks
           }
 
-          return oldTasks.map((task) =>
-            task.id === updatedTask.id ? updatedTask : task,
-          )
+          return {
+            ...oldTasks,
+            data: oldTasks.data.map((task) =>
+              task.id === updatedTask.id ? updatedTask : task,
+            ),
+          }
         },
       )
 


### PR DESCRIPTION
## Resumo
- ajusta a API de listagem de tarefas para aceitar filtros de paginação e retornar `PaginatedResponse`
- atualiza a TasksPage para consumir os novos dados paginados na query do React Query
- adiciona testes unitários garantindo o parse da resposta paginada e a propagação de filtros `page` e `size`

## Testes
- pnpm --filter @apps/web test

------
https://chatgpt.com/codex/tasks/task_e_68e70dfd929c832b8907a5848e9240d0