### PR TITLE
Adjust API gateway rate limit defaults

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -3,8 +3,8 @@ NODE_ENV=development
 PORT=3001
 
 # Rate limiting configuration
-RATE_LIMIT_TTL=60
-RATE_LIMIT_LIMIT=120
+RATE_LIMIT_TTL=1
+RATE_LIMIT_LIMIT=10
 
 # Authentication service RPC client
 AUTH_SERVICE_HOST=127.0.0.1

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -18,14 +18,14 @@ import { TasksModule } from './tasks/tasks.module';
       imports: [ConfigModule],
       inject: [ConfigService],
       useFactory: (config: ConfigService) => {
-        const ttl = parseInt(config.get<string>('RATE_LIMIT_TTL', '60'), 10);
+        const ttl = parseInt(config.get<string>('RATE_LIMIT_TTL', '1'), 10);
         const limit = parseInt(
-          config.get<string>('RATE_LIMIT_LIMIT', '120'),
+          config.get<string>('RATE_LIMIT_LIMIT', '10'),
           10,
         );
 
-        const normalizedTtl = Number.isNaN(ttl) ? 60 : ttl;
-        const normalizedLimit = Number.isNaN(limit) ? 120 : limit;
+        const normalizedTtl = Number.isNaN(ttl) ? 1 : ttl;
+        const normalizedLimit = Number.isNaN(limit) ? 10 : limit;
 
         return [
           {


### PR DESCRIPTION
## Summary
- set the API gateway throttler defaults to 1 second TTL and a 10 request limit when env vars are absent
- update the API .env example to reflect the new rate limiting guidance

## Testing
- `SKIP_MICROSERVICES=true pnpm --filter @apps/api-gateway start`
- `node - <<'NODE' ...`

------
https://chatgpt.com/codex/tasks/task_e_68e70e1bfdc0832ba64cbbd0f361e7a2