### PR TITLE
feat: add pagination controls to tasks page

### DIFF
--- a/apps/web/src/features/tasks/components/TaskFilters.tsx
+++ b/apps/web/src/features/tasks/components/TaskFilters.tsx
@@ -19,6 +19,7 @@ import {
   useTasksFilters,
 } from '../store/useTasksFilters'
 import { useTaskCreationModal } from '../store/useTaskCreationModal'
+import { useTasksPagination } from '../store/useTasksPagination'
 
 const statusLabels: Record<Exclude<StatusFilter, 'ALL'>, string> = {
   [TaskStatus.TODO]: 'A fazer',
@@ -59,18 +60,22 @@ export function TaskFilters({ className, onCreateTask }: TaskFiltersProps) {
   const { status, setStatus, priority, setPriority, dueDate, setDueDate } =
     useTasksFilters()
   const { open } = useTaskCreationModal()
+  const { resetPagination } = useTasksPagination()
 
   const handleStatusChange = (value: string) => {
     setStatus(value as StatusFilter)
+    resetPagination()
   }
 
   const handlePriorityChange = (value: string) => {
     setPriority(value as PriorityFilter)
+    resetPagination()
   }
 
   const handleDueDateChange = (event: ChangeEvent<HTMLInputElement>) => {
     const value = event.target.value.trim()
     setDueDate(value ? value : null)
+    resetPagination()
   }
 
   const handleCreateTaskClick = () => {

--- a/apps/web/src/features/tasks/components/TasksPagination.tsx
+++ b/apps/web/src/features/tasks/components/TasksPagination.tsx
@@ -1,0 +1,106 @@
+import type { PaginationMeta } from '@repo/types'
+
+import { Button } from '@/components/ui/button'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { cn } from '@/lib/utils'
+
+interface TasksPaginationProps {
+  page: number
+  pageSize: number
+  meta?: PaginationMeta
+  onPageChange: (page: number) => void
+  onPageSizeChange: (size: number) => void
+  className?: string
+}
+
+const pageSizeOptions = [10, 20, 50] as const
+
+function formatRange(meta: PaginationMeta) {
+  if (meta.total === 0) {
+    return 'Mostrando 0–0 de 0'
+  }
+
+  const currentPage = Math.max(1, meta.page)
+  const pageSize = Math.max(1, meta.size)
+  const start = (currentPage - 1) * pageSize + 1
+  const end = Math.min(currentPage * pageSize, meta.total)
+
+  return `Mostrando ${start}–${end} de ${meta.total}`
+}
+
+export function TasksPagination({
+  page,
+  pageSize,
+  meta,
+  onPageChange,
+  onPageSizeChange,
+  className,
+}: TasksPaginationProps) {
+  const hasMeta = Boolean(meta)
+  const isFirstPage = page <= 1
+  const isLastPage = hasMeta
+    ? meta!.totalPages <= 0 || page >= meta!.totalPages
+    : true
+
+  return (
+    <div
+      className={cn(
+        'flex w-full flex-col items-center justify-between gap-3 rounded-lg border border-border bg-card/40 p-4 text-sm sm:flex-row',
+        className,
+      )}
+    >
+      <div className="flex items-center gap-3">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={isFirstPage || !hasMeta}
+          onClick={() => onPageChange(Math.max(1, page - 1))}
+        >
+          Anterior
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={isLastPage}
+          onClick={() => onPageChange(page + 1)}
+        >
+          Próxima
+        </Button>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+          Itens por página
+        </span>
+        <Select
+          value={pageSize.toString()}
+          onValueChange={(value) => onPageSizeChange(Number(value))}
+          disabled={!hasMeta}
+        >
+          <SelectTrigger aria-label="Itens por página" size="sm">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {pageSizeOptions.map((option) => (
+              <SelectItem key={option} value={option.toString()}>
+                {option} por página
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="text-xs text-muted-foreground" aria-live="polite">
+        {hasMeta ? formatRange(meta!) : 'Carregando paginação...'}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/features/tasks/pages/TasksPage.tsx
+++ b/apps/web/src/features/tasks/pages/TasksPage.tsx
@@ -1,6 +1,11 @@
-import { useEffect, useMemo, useRef } from 'react'
+import { useCallback, useEffect, useMemo, useRef } from 'react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
-import type { CommentDTO, PaginatedResponse, Task, TaskEventPayload } from '@repo/types'
+import type {
+  CommentDTO,
+  PaginatedResponse,
+  Task,
+  TaskEventPayload,
+} from '@repo/types'
 
 import { Button } from '@/components/ui/button'
 import { toast } from '@/components/ui/use-toast'
@@ -14,9 +19,11 @@ import { SearchBar } from '../components/SearchBar'
 import { TableView } from '../components/TableView'
 import { TaskFilters } from '../components/TaskFilters'
 import { TaskModal } from '../components/TaskModal'
+import { TasksPagination } from '../components/TasksPagination'
 import { ViewSwitcher } from '../components/ViewSwitcher'
 import { useTaskCreationModal } from '../store/useTaskCreationModal'
 import { useTasksFilters } from '../store/useTasksFilters'
+import { useTasksPagination } from '../store/useTasksPagination'
 import { useTasksView } from '../store/useTasksView'
 
 const containerClassName =
@@ -33,22 +40,36 @@ export function TasksPage() {
     searchTerm,
     setSearchTerm,
   } = useTasksFilters()
+  const { page, pageSize, setPage, setPageSize, resetPagination } =
+    useTasksPagination()
   const { viewMode } = useTasksView()
   const creationModal = useTaskCreationModal()
   const queryClient = useQueryClient()
   const wasDisconnectedRef = useRef(false)
 
-  const filters = useMemo<Pick<GetTasksFilters, 'status' | 'priority' | 'dueDate' | 'searchTerm'>>(
-    () => ({ status, priority, dueDate, searchTerm }),
-    [status, priority, dueDate, searchTerm],
+  const filters = useMemo<
+    Pick<GetTasksFilters, 'status' | 'priority' | 'dueDate' | 'searchTerm' | 'page' | 'size'>
+  >(
+    () => ({
+      status,
+      priority,
+      dueDate,
+      searchTerm,
+      page,
+      size: pageSize,
+    }),
+    [status, priority, dueDate, searchTerm, page, pageSize],
   )
 
   const tasksQuery = useQuery({
     queryKey: ['tasks', filters],
     queryFn: () => getTasks(filters),
+    keepPreviousData: true,
   })
 
-  const tasks = tasksQuery.data?.data ?? []
+  const tasksResponse = tasksQuery.data
+  const tasks = tasksResponse?.data ?? []
+  const paginationMeta = tasksResponse?.meta
   const isPending = tasksQuery.isPending
   const isFetching = tasksQuery.isFetching
   const isLoading = isPending || (isFetching && tasks.length === 0)
@@ -97,10 +118,10 @@ export function TasksPage() {
           }
 
           return {
-            ...oldTasks,
             data: oldTasks.data.map((task) =>
               task.id === updatedTask.id ? updatedTask : task,
             ),
+            meta: oldTasks.meta,
           }
         },
       )
@@ -177,6 +198,45 @@ export function TasksPage() {
     }
   }, [queryClient])
 
+  useEffect(() => {
+    if (!paginationMeta) {
+      return
+    }
+
+    const maxPage = Math.max(1, paginationMeta.totalPages)
+
+    if (page > maxPage) {
+      setPage(maxPage)
+    }
+  }, [page, paginationMeta, setPage])
+
+  const handleSearchTermChange = useCallback(
+    (term: string) => {
+      if (term === searchTerm) {
+        return
+      }
+
+      setSearchTerm(term)
+      resetPagination()
+    },
+    [resetPagination, searchTerm, setSearchTerm],
+  )
+
+  const handlePageChange = useCallback(
+    (newPage: number) => {
+      setPage(Math.max(1, newPage))
+    },
+    [setPage],
+  )
+
+  const handlePageSizeChange = useCallback(
+    (newPageSize: number) => {
+      setPageSize(newPageSize)
+      setPage(1)
+    },
+    [setPage, setPageSize],
+  )
+
   return (
     <main className={containerClassName}>
       <header className="space-y-2">
@@ -198,7 +258,7 @@ export function TasksPage() {
               params: { taskId },
             })
           }}
-          onSearchTermChange={setSearchTerm}
+          onSearchTermChange={handleSearchTermChange}
         />
 
         <ViewSwitcher className="md:self-end" />
@@ -246,6 +306,16 @@ export function TasksPage() {
           />
       )}
       </section>
+
+      <div className="flex justify-end">
+        <TasksPagination
+          page={page}
+          pageSize={pageSize}
+          meta={paginationMeta}
+          onPageChange={handlePageChange}
+          onPageSizeChange={handlePageSizeChange}
+        />
+      </div>
 
       <TaskModal
         open={isModalOpen}

--- a/apps/web/src/features/tasks/pages/__tests__/TasksPage.test.tsx
+++ b/apps/web/src/features/tasks/pages/__tests__/TasksPage.test.tsx
@@ -1,0 +1,301 @@
+import 'reflect-metadata'
+
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { PaginatedResponse, PaginationMeta, Task } from '@repo/types'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useTasksFilters } from '../../store/useTasksFilters'
+import { useTasksPagination } from '../../store/useTasksPagination'
+import { getTasks } from '../../api/getTasks'
+
+vi.mock('@/lib/ws-client', () => ({
+  socket: {
+    on: vi.fn(),
+    off: vi.fn(),
+  },
+}))
+
+vi.mock('@/components/ui/use-toast', () => ({
+  toast: vi.fn(),
+}))
+
+vi.mock('@/router', () => ({
+  router: {
+    navigate: vi.fn(),
+  },
+}))
+
+vi.mock('../../components/CardsView', () => ({
+  CardsView: ({ isLoading }: { isLoading: boolean }) => (
+    <div data-testid="cards-view">{isLoading ? 'carregando' : 'loaded'}</div>
+  ),
+}))
+
+vi.mock('../../components/TableView', () => ({
+  TableView: ({ isLoading }: { isLoading: boolean }) => (
+    <div data-testid="table-view">{isLoading ? 'carregando' : 'loaded'}</div>
+  ),
+}))
+
+vi.mock('../../components/KanbanView', () => ({
+  KanbanView: ({ isLoading }: { isLoading: boolean }) => (
+    <div data-testid="kanban-view">{isLoading ? 'carregando' : 'loaded'}</div>
+  ),
+}))
+
+vi.mock('../../components/TaskModal', () => ({
+  TaskModal: () => null,
+}))
+
+vi.mock('../../components/ViewSwitcher', () => ({
+  ViewSwitcher: () => <div data-testid="view-switcher" />,
+}))
+
+vi.mock('../../components/TasksPagination', () => ({
+  TasksPagination: ({
+    page,
+    pageSize,
+    meta,
+    onPageChange,
+    onPageSizeChange,
+  }: {
+    page: number
+    pageSize: number
+    meta?: PaginationMeta
+    onPageChange: (page: number) => void
+    onPageSizeChange: (size: number) => void
+  }) => {
+    const formatRange = (pagination: PaginationMeta) => {
+      if (pagination.total === 0) {
+        return 'Mostrando 0–0 de 0'
+      }
+
+      const start = (pagination.page - 1) * pagination.size + 1
+      const end = Math.min(pagination.page * pagination.size, pagination.total)
+
+      return `Mostrando ${start}–${end} de ${pagination.total}`
+    }
+
+    return (
+      <div>
+        <button
+          type="button"
+          onClick={() => onPageChange(page - 1)}
+          disabled={page <= 1}
+        >
+          Anterior
+        </button>
+        <button
+          type="button"
+          onClick={() => onPageChange(page + 1)}
+          disabled={!meta || page >= meta.totalPages}
+        >
+          Próxima
+        </button>
+        <label>
+          Itens por página
+          <select
+            aria-label="Itens por página"
+            value={pageSize}
+            onChange={(event) => onPageSizeChange(Number(event.target.value))}
+          >
+            <option value={10}>10 por página</option>
+            <option value={20}>20 por página</option>
+            <option value={50}>50 por página</option>
+          </select>
+        </label>
+        <span>{meta ? formatRange(meta) : 'Carregando paginação...'}</span>
+      </div>
+    )
+  },
+}))
+
+vi.mock('../../api/getTasks', () => ({
+  getTasks: vi.fn(),
+}))
+
+const { TasksPage } = await import('../TasksPage')
+
+const getTasksMock = getTasks as unknown as vi.MockedFunction<typeof getTasks>
+
+const createdClients: QueryClient[] = []
+
+beforeAll(() => {
+  Object.defineProperty(window.HTMLElement.prototype, 'hasPointerCapture', {
+    configurable: true,
+    value: () => false,
+  })
+
+  Object.defineProperty(window.HTMLElement.prototype, 'setPointerCapture', {
+    configurable: true,
+    value: () => {},
+  })
+
+  Object.defineProperty(window.HTMLElement.prototype, 'releasePointerCapture', {
+    configurable: true,
+    value: () => {},
+  })
+})
+
+function renderTasksPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  })
+
+  createdClients.push(queryClient)
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <TasksPage />
+    </QueryClientProvider>,
+  )
+}
+
+beforeEach(() => {
+  vi.useRealTimers()
+
+  getTasksMock.mockImplementation(async (filters): Promise<PaginatedResponse<Task>> => {
+    const total = 100
+    const size = filters?.size ?? 10
+    const totalPages = Math.max(1, Math.ceil(total / size))
+    const requestedPage = filters?.page ?? 1
+    const page = Math.min(Math.max(1, requestedPage), totalPages)
+
+    return {
+      data: [],
+      meta: {
+        total,
+        page,
+        size,
+        totalPages,
+      },
+    }
+  })
+
+  useTasksFilters.setState({
+    searchTerm: '',
+    status: 'ALL',
+    priority: 'ALL',
+    dueDate: null,
+  })
+
+  useTasksPagination.setState({
+    page: 1,
+    pageSize: 10,
+  })
+})
+
+afterEach(() => {
+  getTasksMock.mockReset()
+  createdClients.forEach((client) => client.clear())
+  createdClients.length = 0
+})
+
+const SEARCH_DEBOUNCE_MS = 500
+
+describe('TasksPage - paginação', () => {
+  it('permite navegar entre páginas e alterar o tamanho', async () => {
+    renderTasksPage()
+
+    await waitFor(() => {
+      expect(getTasksMock).toHaveBeenCalled()
+    })
+
+    await screen.findByText('Mostrando 1–10 de 100')
+
+    const [nextButton] = screen.getAllByRole('button', { name: 'Próxima' })
+    fireEvent.click(nextButton)
+
+    await waitFor(() => {
+      expect(useTasksPagination.getState().page).toBe(2)
+    })
+
+    const pageSizeTrigger = screen.getByLabelText('Itens por página')
+    fireEvent.change(pageSizeTrigger, { target: { value: '20' } })
+
+    await waitFor(() => {
+      const state = useTasksPagination.getState()
+      expect(state.page).toBe(1)
+      expect(state.pageSize).toBe(20)
+    })
+
+    await waitFor(() => {
+      expect(
+        getTasksMock.mock.calls.some((call) =>
+          call[0] && 'size' in call[0] && call[0]?.size === 20,
+        ),
+      ).toBe(true)
+    })
+  })
+
+  it('reseta a paginação ao alterar o termo de busca', async () => {
+    renderTasksPage()
+
+    await waitFor(() => {
+      expect(getTasksMock).toHaveBeenCalled()
+    })
+
+    const [nextButton] = screen.getAllByRole('button', { name: 'Próxima' })
+    fireEvent.click(nextButton)
+
+    const [searchInput] = screen.getAllByRole('searchbox')
+    fireEvent.change(searchInput, { target: { value: 'nova busca' } })
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, SEARCH_DEBOUNCE_MS))
+    })
+
+    await waitFor(() => {
+      expect(
+        getTasksMock.mock.calls.some((call) => {
+          const args = call[0] as Record<string, unknown> | undefined
+          return (
+            args?.page === 1 &&
+            args?.size === 10 &&
+            args?.searchTerm === 'nova busca'
+          )
+        }),
+      ).toBe(true)
+    })
+
+    await waitFor(() => {
+      expect(useTasksPagination.getState().page).toBe(1)
+    })
+  })
+
+  it('reseta a paginação ao alterar os filtros', async () => {
+    renderTasksPage()
+
+    await waitFor(() => {
+      expect(getTasksMock).toHaveBeenCalled()
+    })
+
+    const [nextButton] = screen.getAllByRole('button', { name: 'Próxima' })
+    fireEvent.click(nextButton)
+
+    const dueDateInput = screen.getByLabelText('Prazo')
+    fireEvent.change(dueDateInput, { target: { value: '2024-01-01' } })
+
+    await waitFor(() => {
+      expect(
+        getTasksMock.mock.calls.some((call) => {
+          const args = call[0] as Record<string, unknown> | undefined
+          return (
+            args?.page === 1 &&
+            args?.size === 10 &&
+            args?.dueDate === '2024-01-01'
+          )
+        }),
+      ).toBe(true)
+    })
+
+    await waitFor(() => {
+      expect(useTasksPagination.getState().page).toBe(1)
+    })
+  })
+})

--- a/apps/web/src/features/tasks/store/useTasksPagination.ts
+++ b/apps/web/src/features/tasks/store/useTasksPagination.ts
@@ -1,0 +1,25 @@
+import { create } from 'zustand'
+
+interface TasksPaginationState {
+  page: number
+  pageSize: number
+  setPage: (page: number) => void
+  setPageSize: (pageSize: number) => void
+  resetPagination: () => void
+}
+
+const initialState = {
+  page: 1,
+  pageSize: 10,
+} satisfies Pick<TasksPaginationState, 'page' | 'pageSize'>
+
+export const useTasksPagination = create<TasksPaginationState>((set) => ({
+  ...initialState,
+  setPage: (page) => set({ page }),
+  setPageSize: (pageSize) => set({ pageSize }),
+  resetPagination: () =>
+    set((state) => ({
+      page: initialState.page,
+      pageSize: state.pageSize,
+    })),
+}))


### PR DESCRIPTION
## Summary
- add Zustand store to centralize tasks pagination state and expose helpers
- integrate pagination metadata on the Tasks page with websocket updates and reset hooks
- introduce pagination UI component and RTL tests covering navigation and filter resets

## Testing
- pnpm --filter @apps/web test

------
https://chatgpt.com/codex/tasks/task_e_68e70f8b96d4832b85279153aa51108d