### PR TITLE
feat: expose task comment created event payload

### DIFF
--- a/apps/auth/src/types-contracts.spec.ts
+++ b/apps/auth/src/types-contracts.spec.ts
@@ -37,6 +37,8 @@ describe("@repo/types runtime contract", () => {
     expect(TASK_EVENT_PATTERNS).toEqual(
       expect.objectContaining({
         CREATED: "task.created",
+        UPDATED: "task.updated",
+        DELETED: "task.deleted",
         COMMENT_CREATED: "task.comment.created",
       }),
     );

--- a/packages/types/src/contracts/events/tasks.ts
+++ b/packages/types/src/contracts/events/tasks.ts
@@ -22,9 +22,9 @@ export interface TaskEventPayload {
   changes?: TaskAuditLogChangeDTO[] | Record<string, unknown> | null;
 }
 
-export interface TaskCommentCreatedEventPayload {
+export interface TaskCommentCreatedEventPayload
+  extends Pick<TaskEventPayload, "recipients"> {
   comment: CommentDTO;
-  recipients: string[];
 }
 
 export const TASK_FORWARDING_PATTERNS = {
@@ -35,8 +35,8 @@ export const TASK_FORWARDING_PATTERNS = {
 export type TaskForwardingPattern =
   (typeof TASK_FORWARDING_PATTERNS)[keyof typeof TASK_FORWARDING_PATTERNS];
 
-export interface TaskCommentCreatedPayload {
-  comment: CommentDTO;
+export interface TaskCommentCreatedPayload
+  extends TaskCommentCreatedEventPayload {
   recipients: string[];
 }
 


### PR DESCRIPTION
## Summary
- reuse the task event recipients contract in the comment created event payload and forward payload
- ensure the auth service contract test asserts the available task event patterns including comment creation

## Testing
- pnpm --filter @apps/auth-service test -- types-contracts.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68e716329850832bb20f9b9866cf5a60