### PR TITLE
feat(notifications): configure database connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Monorepo Turborepo com os serviços do JungleGaming (gateway HTTP, auth, tasks, 
 
 ## Onboarding rápido
 1. Instale dependências com `pnpm install`.
-2. Configure as variáveis de ambiente copiando os arquivos `.env.example` dentro de cada app (ex.: `cp apps/auth/.env.example apps/auth/.env`).
+2. Configure as variáveis de ambiente copiando os arquivos `.env.example` dentro de cada app (ex.: `cp apps/auth/.env.example apps/auth/.env`). O serviço de notificações agora também espera `DATABASE_URL` apontando para o Postgres, assim como Auth e Tasks.
 3. Ajuste os segredos JWT compartilhados entre Auth e API (`JWT_SECRET`, `JWT_EXPIRES_IN`, `JWT_ACCESS_SECRET`, `JWT_ACCESS_EXPIRES`). Os valores precisam coincidir para que a validação do token funcione em todo o ecossistema.
 4. Suba os serviços com `pnpm dev` para desenvolvimento local ou `docker compose up` para a stack completa (Postgres, RabbitMQ e serviços NestJS).
 

--- a/apps/notifications/.env.example
+++ b/apps/notifications/.env.example
@@ -1,6 +1,9 @@
 # Notifications service environment variables
 NODE_ENV=development
 
+# PostgreSQL connection string
+DATABASE_URL=postgres://postgres:password@localhost:5432/challenge_db
+
 # RabbitMQ configuration
 RABBITMQ_URL=amqp://admin:admin@localhost:5672
 RABBITMQ_QUEUE=notifications.events

--- a/apps/notifications/package.json
+++ b/apps/notifications/package.json
@@ -27,9 +27,12 @@
     "@nestjs/platform-express": "^11.0.1",
     "@nestjs/swagger": "^11.2.0",
     "@nestjs/terminus": "^11.0.0",
+    "@nestjs/typeorm": "^11.0.0",
     "@repo/types": "workspace:*",
+    "pg": "^8.16.3",
     "reflect-metadata": "^0.2.2",
-    "rxjs": "^7.8.1"
+    "rxjs": "^7.8.1",
+    "typeorm": "^0.3.27"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",

--- a/apps/notifications/src/app.module.ts
+++ b/apps/notifications/src/app.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { ClientsModule, Transport } from '@nestjs/microservices';
+import { TypeOrmModule } from '@nestjs/typeorm';
 
 import {
   NOTIFICATIONS_GATEWAY_CLIENT,
@@ -9,9 +10,33 @@ import {
 import { HealthModule } from './health/health.module';
 import { NotificationsService } from './notifications.service';
 
+const validateEnv = (config: Record<string, unknown>) => {
+  const databaseUrl = config['DATABASE_URL'];
+
+  if (typeof databaseUrl !== 'string' || databaseUrl.trim().length === 0) {
+    throw new Error('DATABASE_URL must be defined as a non-empty string');
+  }
+
+  return config;
+};
+
 @Module({
   imports: [
-    ConfigModule.forRoot({ isGlobal: true }),
+    ConfigModule.forRoot({
+      isGlobal: true,
+      envFilePath: ['.env'],
+      validate: validateEnv,
+    }),
+    TypeOrmModule.forRootAsync({
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory: (configService: ConfigService) => ({
+        type: 'postgres',
+        url: configService.getOrThrow<string>('DATABASE_URL'),
+        autoLoadEntities: true,
+        synchronize: true,
+      }),
+    }),
     ClientsModule.registerAsync([
       {
         name: NOTIFICATIONS_GATEWAY_CLIENT,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -150,9 +150,12 @@ services:
     environment:
       NODE_ENV: development
       PORT: ${NOTIFICATIONS_PORT:-3005}
+      DATABASE_URL: postgres://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-password}@db:5432/${POSTGRES_DB:-challenge_db}
       RABBITMQ_URL: amqp://${RABBITMQ_USER:-admin}:${RABBITMQ_PASS:-admin}@rabbitmq:5672
       CORS_ORIGIN: ${CORS_ORIGIN:-http://localhost:3000}
     depends_on:
+      db:
+        condition: service_healthy
       rabbitmq:
         condition: service_healthy
     ports:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -349,15 +349,24 @@ importers:
       '@nestjs/terminus':
         specifier: ^11.0.0
         version: 11.0.0(@nestjs/axios@4.0.1(@nestjs/common@11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(axios@1.12.2)(rxjs@7.8.2))(@nestjs/common@11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.6(@nestjs/common@11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/microservices@11.1.6)(@nestjs/platform-express@11.1.6)(@nestjs/websockets@11.1.6)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/microservices@11.1.6(@nestjs/common@11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.6)(@nestjs/websockets@11.1.6)(amqp-connection-manager@5.0.0(amqplib@0.10.9))(amqplib@0.10.9)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/typeorm@11.0.0(@nestjs/common@11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.6(@nestjs/common@11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/microservices@11.1.6)(@nestjs/platform-express@11.1.6)(@nestjs/websockets@11.1.6)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)(typeorm@0.3.27(pg@8.16.3)(reflect-metadata@0.2.2)(sql.js@1.13.0)(ts-node@10.9.2(@types/node@22.15.3)(typescript@5.9.2))))(reflect-metadata@0.2.2)(rxjs@7.8.2)(typeorm@0.3.27(pg@8.16.3)(reflect-metadata@0.2.2)(sql.js@1.13.0)(ts-node@10.9.2(@types/node@22.15.3)(typescript@5.9.2)))
+      '@nestjs/typeorm':
+        specifier: ^11.0.0
+        version: 11.0.0(@nestjs/common@11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.6(@nestjs/common@11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/microservices@11.1.6)(@nestjs/platform-express@11.1.6)(@nestjs/websockets@11.1.6)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)(typeorm@0.3.27(pg@8.16.3)(reflect-metadata@0.2.2)(sql.js@1.13.0)(ts-node@10.9.2(@types/node@22.15.3)(typescript@5.9.2)))
       '@repo/types':
         specifier: workspace:*
         version: link:../../packages/types
+      pg:
+        specifier: ^8.16.3
+        version: 8.16.3
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
       rxjs:
         specifier: ^7.8.1
         version: 7.8.2
+      typeorm:
+        specifier: ^0.3.27
+        version: 0.3.27(pg@8.16.3)(reflect-metadata@0.2.2)(sql.js@1.13.0)(ts-node@10.9.2(@types/node@22.15.3)(typescript@5.9.2))
     devDependencies:
       '@eslint/eslintrc':
         specifier: ^3.2.0


### PR DESCRIPTION
## Summary
- load environment variables in the notifications service via ConfigModule validation and require DATABASE_URL
- register the PostgreSQL connection with TypeORM and add the needed dependencies and container variables
- document the new DATABASE_URL requirement and expose it in the sample env and docker compose

## Testing
- pnpm --filter @apps/notifications-service lint *(fails: pre-existing @typescript-eslint/no-unsafe-* violations)*

------
https://chatgpt.com/codex/tasks/task_e_68e71f70da5c832ba83134a7f88f8abc