### PR TITLE
feat: add notification entity

### DIFF
--- a/apps/notifications/src/app.module.ts
+++ b/apps/notifications/src/app.module.ts
@@ -9,6 +9,7 @@ import {
 } from './notifications.constants';
 import { HealthModule } from './health/health.module';
 import { NotificationsService } from './notifications.service';
+import { Notification } from './notifications/notification.entity';
 
 const validateEnv = (config: Record<string, unknown>) => {
   const databaseUrl = config['DATABASE_URL'];
@@ -35,6 +36,7 @@ const validateEnv = (config: Record<string, unknown>) => {
         url: configService.getOrThrow<string>('DATABASE_URL'),
         autoLoadEntities: true,
         synchronize: true,
+        entities: [Notification],
       }),
     }),
     ClientsModule.registerAsync([

--- a/apps/notifications/src/notifications/notification.entity.ts
+++ b/apps/notifications/src/notifications/notification.entity.ts
@@ -1,0 +1,48 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import type { NotificationChannel, NotificationStatus } from '@repo/types';
+import { NOTIFICATION_CHANNELS, NOTIFICATION_STATUSES } from '@repo/types';
+
+@Index('idx_notifications_recipient', ['recipientId'])
+@Index('idx_notifications_status', ['status'])
+@Index('idx_notifications_created_at', ['createdAt'])
+@Entity({ name: 'notifications' })
+export class Notification {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'uuid' })
+  recipientId: string;
+
+  @Column({
+    type: 'enum',
+    enum: NOTIFICATION_CHANNELS,
+    enumName: 'notification_channel_enum',
+  })
+  channel: NotificationChannel;
+
+  @Column({
+    type: 'enum',
+    enum: NOTIFICATION_STATUSES,
+    enumName: 'notification_status_enum',
+    default: 'pending',
+  })
+  status: NotificationStatus;
+
+  @Column({ type: 'text' })
+  message: string;
+
+  @Column({ type: 'jsonb', nullable: true })
+  metadata?: Record<string, unknown> | null;
+
+  @CreateDateColumn({ type: 'timestamptz' })
+  createdAt: Date;
+
+  @Column({ type: 'timestamptz', nullable: true })
+  sentAt?: Date | null;
+}


### PR DESCRIPTION
## Summary
- create a Notification TypeORM entity aligned with the shared notification DTO definitions, including indexes for frequent queries
- register the notification entity with the notifications service database configuration so the schema can be synchronized

## Testing
- pnpm --filter @apps/notifications-service lint *(fails: existing @typescript-eslint/no-unsafe-* violations across the project)*

------
https://chatgpt.com/codex/tasks/task_e_68e721742d40832b9c8a860c1d8fdb76