### PR TITLE
feat: persist notifications before gateway forwarding

### DIFF
--- a/apps/notifications/src/notifications.service.spec.ts
+++ b/apps/notifications/src/notifications.service.spec.ts
@@ -1,0 +1,204 @@
+import { of, throwError } from 'rxjs'
+import type { ClientProxy, RmqContext } from '@nestjs/microservices'
+import type {
+  TaskCommentCreatedPayload,
+  TaskUpdatedForwardPayload,
+} from '@repo/types'
+
+import { NotificationsService } from './notifications.service'
+import type { NotificationsPersistenceService } from './notifications/persistence/notifications-persistence.service'
+
+describe('NotificationsService', () => {
+  let service: NotificationsService
+  let emitMock: jest.Mock
+  let createNotificationMock: jest.Mock
+  let gatewayClient: ClientProxy
+  let notificationsPersistence: NotificationsPersistenceService
+
+  const createContext = () => {
+    const ack = jest.fn()
+    const nack = jest.fn()
+    const channel = { ack, nack }
+    const message = { content: Buffer.from('test') }
+    const context = {
+      getChannelRef: jest.fn().mockReturnValue(channel),
+      getMessage: jest.fn().mockReturnValue(message),
+    } as unknown as RmqContext
+
+    return { context, channel }
+  }
+
+  beforeEach(() => {
+    emitMock = jest.fn()
+    createNotificationMock = jest.fn()
+
+    gatewayClient = { emit: emitMock } as unknown as ClientProxy
+    notificationsPersistence = {
+      createNotification: createNotificationMock,
+    } as unknown as NotificationsPersistenceService
+
+    service = new NotificationsService(gatewayClient, notificationsPersistence)
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('persists notifications for new comments before forwarding the event', async () => {
+    const { context, channel } = createContext()
+    const payload: TaskCommentCreatedPayload = {
+      comment: {
+        id: 'comment-1',
+        taskId: 'task-1',
+        authorId: 'author-1',
+        authorName: '  Maria  ',
+        message: 'Um novo comentário',
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      },
+      recipients: ['user-1', 'user-2', 'user-1'],
+    }
+
+    createNotificationMock.mockResolvedValue(undefined)
+    emitMock.mockReturnValue(of(undefined))
+
+    await service.handleNewComment(payload, context)
+
+    expect(createNotificationMock).toHaveBeenCalledTimes(2)
+    expect(createNotificationMock).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        recipientId: 'user-1',
+        channel: 'in_app',
+        message: 'Maria comentou na tarefa task-1',
+        metadata: expect.objectContaining({
+          taskId: 'task-1',
+          commentId: 'comment-1',
+          commentAuthorName: 'Maria',
+        }),
+      }),
+    )
+    expect(createNotificationMock).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ recipientId: 'user-2' }),
+    )
+    expect(emitMock).toHaveBeenCalledTimes(1)
+    expect(channel.ack).toHaveBeenCalledTimes(1)
+    expect(channel.nack).not.toHaveBeenCalled()
+  })
+
+  it('nacks the message and skips forwarding when persistence fails for comments', async () => {
+    const { context, channel } = createContext()
+    const payload: TaskCommentCreatedPayload = {
+      comment: {
+        id: 'comment-2',
+        taskId: 'task-2',
+        authorId: 'author-2',
+        authorName: 'João',
+        message: 'Outro comentário',
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      },
+      recipients: ['user-3'],
+    }
+
+    createNotificationMock.mockRejectedValue(new Error('db offline'))
+
+    await service.handleNewComment(payload, context)
+
+    expect(createNotificationMock).toHaveBeenCalledTimes(1)
+    expect(emitMock).not.toHaveBeenCalled()
+    expect(channel.ack).not.toHaveBeenCalled()
+    expect(channel.nack).toHaveBeenCalledTimes(1)
+  })
+
+  it('nacks the message when forwarding the comment event fails', async () => {
+    const { context, channel } = createContext()
+    const payload: TaskCommentCreatedPayload = {
+      comment: {
+        id: 'comment-3',
+        taskId: 'task-3',
+        authorId: 'author-3',
+        authorName: null,
+        message: 'Falha no envio',
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      },
+      recipients: ['user-4'],
+    }
+
+    createNotificationMock.mockResolvedValue(undefined)
+    emitMock.mockReturnValue(throwError(() => new Error('gateway error')))
+
+    await service.handleNewComment(payload, context)
+
+    expect(createNotificationMock).toHaveBeenCalledTimes(1)
+    expect(emitMock).toHaveBeenCalledTimes(1)
+    expect(channel.ack).not.toHaveBeenCalled()
+    expect(channel.nack).toHaveBeenCalledTimes(1)
+  })
+
+  it('persists task update notifications with metadata before forwarding', async () => {
+    const { context, channel } = createContext()
+    const payload: TaskUpdatedForwardPayload = {
+      task: {
+        id: 'task-10',
+        title: ' Revisão de código ',
+      },
+      recipients: ['user-10'],
+      actor: {
+        id: 'actor-1',
+        displayName: '  Ana  ',
+      },
+      changes: [
+        {
+          field: 'status',
+          previousValue: 'todo',
+          currentValue: 'doing',
+        },
+      ],
+    }
+
+    createNotificationMock.mockResolvedValue(undefined)
+    emitMock.mockReturnValue(of(undefined))
+
+    await service.handleTaskUpdated(payload, context)
+
+    expect(createNotificationMock).toHaveBeenCalledTimes(1)
+    expect(createNotificationMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        recipientId: 'user-10',
+        message: 'Ana atualizou a tarefa Revisão de código',
+        metadata: expect.objectContaining({
+          taskId: 'task-10',
+          taskTitle: 'Revisão de código',
+          actorId: 'actor-1',
+          actorDisplayName: 'Ana',
+          changes: payload.changes,
+        }),
+      }),
+    )
+    expect(emitMock).toHaveBeenCalledTimes(1)
+    expect(channel.ack).toHaveBeenCalledTimes(1)
+    expect(channel.nack).not.toHaveBeenCalled()
+  })
+
+  it('nacks the message and aborts forwarding when task update persistence fails', async () => {
+    const { context, channel } = createContext()
+    const payload: TaskUpdatedForwardPayload = {
+      task: {
+        id: 'task-20',
+      },
+      recipients: ['user-20'],
+    }
+
+    createNotificationMock.mockRejectedValue(new Error('db unavailable'))
+
+    await service.handleTaskUpdated(payload, context)
+
+    expect(createNotificationMock).toHaveBeenCalledTimes(1)
+    expect(emitMock).not.toHaveBeenCalled()
+    expect(channel.ack).not.toHaveBeenCalled()
+    expect(channel.nack).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/notifications/src/notifications.service.ts
+++ b/apps/notifications/src/notifications.service.ts
@@ -1,8 +1,10 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import { Ctx, EventPattern, Payload, RmqContext } from '@nestjs/microservices';
-import type {
-  TaskCommentCreatedPayload,
-  TaskUpdatedForwardPayload,
+import {
+  NOTIFICATION_CHANNELS,
+  type NotificationChannel,
+  type TaskCommentCreatedPayload,
+  type TaskUpdatedForwardPayload,
 } from '@repo/types';
 import { ClientProxy } from '@nestjs/microservices';
 import { firstValueFrom } from 'rxjs';
@@ -14,6 +16,7 @@ import {
   TASKS_UPDATED_PATTERN,
   TASK_UPDATED_EVENT,
 } from './notifications.constants';
+import { NotificationsPersistenceService } from './notifications/persistence/notifications-persistence.service';
 
 type AcknowledgeMessage = {
   content: Buffer;
@@ -38,10 +41,15 @@ const isAcknowledgeMessage = (value: unknown): value is AcknowledgeMessage =>
 @Injectable()
 export class NotificationsService {
   private readonly logger = new Logger(NotificationsService.name);
+  private readonly inAppChannel: NotificationChannel =
+    NOTIFICATION_CHANNELS.includes('in_app')
+      ? ('in_app' as NotificationChannel)
+      : NOTIFICATION_CHANNELS[0];
 
   constructor(
     @Inject(NOTIFICATIONS_GATEWAY_CLIENT)
     private readonly gatewayClient: ClientProxy,
+    private readonly notificationsPersistence: NotificationsPersistenceService,
   ) {}
 
   @EventPattern(TASKS_COMMENT_CREATED_PATTERN)
@@ -66,6 +74,18 @@ export class NotificationsService {
     const originalMessage = messageRef;
 
     try {
+      await this.persistCommentNotifications(payload);
+    } catch (error) {
+      this.logger.error(
+        `Failed to persist notifications for comment ${
+          payload.comment?.id ?? 'unknown'
+        }: ${this.formatError(error)}`,
+      );
+      channel.nack(originalMessage, false, true);
+      return;
+    }
+
+    try {
       await firstValueFrom(this.gatewayClient.emit(COMMENT_NEW_EVENT, payload));
       channel.ack(originalMessage);
       this.logger.debug(
@@ -73,7 +93,7 @@ export class NotificationsService {
       );
     } catch (error) {
       this.logger.error(
-        `Failed to forward comment ${payload.comment?.id ?? 'unknown'}: ${error instanceof Error ? error.message : error}`,
+        `Failed to forward comment ${payload.comment?.id ?? 'unknown'}: ${this.formatError(error)}`,
       );
       channel.nack(originalMessage, false, true);
     }
@@ -101,6 +121,18 @@ export class NotificationsService {
     const originalMessage = messageRef;
 
     try {
+      await this.persistTaskUpdateNotifications(payload);
+    } catch (error) {
+      this.logger.error(
+        `Failed to persist notifications for task ${
+          this.extractTaskId(payload) ?? 'unknown'
+        } update: ${this.formatError(error)}`,
+      );
+      channel.nack(originalMessage, false, true);
+      return;
+    }
+
+    try {
       await firstValueFrom(
         this.gatewayClient.emit(TASK_UPDATED_EVENT, payload),
       );
@@ -110,9 +142,142 @@ export class NotificationsService {
       );
     } catch (error) {
       this.logger.error(
-        `Failed to forward task ${payload.task?.id ?? 'unknown'} update: ${error instanceof Error ? error.message : error}`,
+        `Failed to forward task ${payload.task?.id ?? 'unknown'} update: ${this.formatError(error)}`,
       );
       channel.nack(originalMessage, false, true);
+    }
+  }
+
+  private async persistCommentNotifications(
+    payload: TaskCommentCreatedPayload,
+  ): Promise<void> {
+    const recipients = this.normalizeRecipients(payload.recipients);
+
+    if (recipients.length === 0) {
+      return;
+    }
+
+    const authorName = this.normalizeText(payload.comment?.authorName);
+    const message = `${authorName ?? 'Alguém'} comentou na tarefa ${
+      payload.comment?.taskId ?? 'desconhecida'
+    }`;
+
+    const metadata = {
+      taskId: payload.comment?.taskId ?? null,
+      commentId: payload.comment?.id ?? null,
+      commentMessage: payload.comment?.message ?? null,
+      commentAuthorId: payload.comment?.authorId ?? null,
+      commentAuthorName: authorName,
+      commentCreatedAt: payload.comment?.createdAt ?? null,
+    } satisfies Record<string, unknown>;
+
+    await Promise.all(
+      recipients.map((recipientId) =>
+        this.notificationsPersistence.createNotification({
+          recipientId,
+          channel: this.inAppChannel,
+          message,
+          metadata,
+        }),
+      ),
+    );
+  }
+
+  private async persistTaskUpdateNotifications(
+    payload: TaskUpdatedForwardPayload,
+  ): Promise<void> {
+    const recipients = this.normalizeRecipients(payload.recipients);
+
+    if (recipients.length === 0) {
+      return;
+    }
+
+    const taskId = this.extractTaskId(payload);
+    const taskTitle = this.extractTaskTitle(payload);
+    const actorDisplayName = this.normalizeText(payload.actor?.displayName);
+
+    const message = `${actorDisplayName ?? 'Sistema'} atualizou a tarefa ${
+      taskTitle ?? taskId ?? 'desconhecida'
+    }`;
+
+    const metadata = {
+      taskId: taskId ?? null,
+      taskTitle: taskTitle ?? null,
+      actorId: payload.actor?.id ?? null,
+      actorDisplayName,
+      changes: payload.changes ?? null,
+    } satisfies Record<string, unknown>;
+
+    await Promise.all(
+      recipients.map((recipientId) =>
+        this.notificationsPersistence.createNotification({
+          recipientId,
+          channel: this.inAppChannel,
+          message,
+          metadata,
+        }),
+      ),
+    );
+  }
+
+  private normalizeRecipients(recipients: string[]): string[] {
+    return Array.from(
+      new Set(
+        (recipients ?? [])
+          .filter((recipient) => typeof recipient === 'string')
+          .map((recipient) => recipient.trim())
+          .filter((recipient) => recipient.length > 0),
+      ),
+    );
+  }
+
+  private normalizeText(value: string | null | undefined): string | null {
+    if (typeof value !== 'string') {
+      return null;
+    }
+
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+
+  private extractTaskId(payload: TaskUpdatedForwardPayload): string | null {
+    if (payload?.task && typeof payload.task === 'object') {
+      const rawId = (payload.task as { id?: unknown }).id;
+      if (typeof rawId === 'string' && rawId.trim().length > 0) {
+        return rawId;
+      }
+    }
+
+    return null;
+  }
+
+  private extractTaskTitle(payload: TaskUpdatedForwardPayload): string | null {
+    if (payload?.task && typeof payload.task === 'object') {
+      const rawTitle = (payload.task as { title?: unknown }).title;
+      if (typeof rawTitle === 'string') {
+        const trimmed = rawTitle.trim();
+        if (trimmed.length > 0) {
+          return trimmed;
+        }
+      }
+    }
+
+    return null;
+  }
+
+  private formatError(error: unknown): string {
+    if (error instanceof Error) {
+      return error.message;
+    }
+
+    if (typeof error === 'string') {
+      return error;
+    }
+
+    try {
+      return JSON.stringify(error);
+    } catch {
+      return 'Unknown error';
     }
   }
 }


### PR DESCRIPTION
## Summary
- persist notifications for comment and task update events before emitting them to the gateway
- enrich saved notifications with contextual metadata and improved error handling
- add unit tests covering persistence success and failure scenarios

## Testing
- pnpm --filter @apps/notifications-service test

------
https://chatgpt.com/codex/tasks/task_e_68e725a35050832bb35062340a809b66