### PR TITLE
test: cover notifications persistence and handlers

### DIFF
--- a/apps/notifications/package.json
+++ b/apps/notifications/package.json
@@ -44,6 +44,7 @@
     "@types/jest": "^30.0.0",
     "@types/node": "^22.10.7",
     "@types/supertest": "^6.0.2",
+    "pg-mem": "^3.0.5",
     "eslint": "^9.18.0",
     "eslint-config-prettier": "^10.0.1",
     "eslint-plugin-prettier": "^5.2.2",

--- a/apps/notifications/src/notifications/notifications.service.integration.spec.ts
+++ b/apps/notifications/src/notifications/notifications.service.integration.spec.ts
@@ -1,0 +1,260 @@
+import { randomUUID } from 'node:crypto';
+import { Test, type TestingModule } from '@nestjs/testing';
+import { getRepositoryToken, TypeOrmModule } from '@nestjs/typeorm';
+import type { Repository } from 'typeorm';
+import { of, throwError } from 'rxjs';
+import type { RmqContext } from '@nestjs/microservices';
+import { DataType, newDb } from 'pg-mem';
+
+import { NotificationsService } from '../notifications.service';
+import { Notification } from './notification.entity';
+import { NotificationsPersistenceService } from './persistence/notifications-persistence.service';
+import { NOTIFICATIONS_GATEWAY_CLIENT } from '../notifications.constants';
+
+const createAckContext = () => {
+  const ack = jest.fn();
+  const nack = jest.fn();
+  const channel = { ack, nack };
+  const message = { content: Buffer.from('payload') };
+
+  const context = {
+    getChannelRef: jest.fn().mockReturnValue(channel),
+    getMessage: jest.fn().mockReturnValue(message),
+  } as unknown as RmqContext;
+
+  return { context, channel, message };
+};
+
+describe('NotificationsService (integração)', () => {
+  let moduleRef: TestingModule;
+  let service: NotificationsService;
+  let repository: Repository<Notification>;
+  let persistence: NotificationsPersistenceService;
+  let emitMock: jest.Mock;
+
+  beforeEach(async () => {
+    emitMock = jest.fn().mockReturnValue(of(undefined));
+
+    moduleRef = await Test.createTestingModule({
+      imports: [
+        TypeOrmModule.forRootAsync({
+          useFactory: async () => ({
+            type: 'postgres',
+            entities: [Notification],
+          }),
+          dataSourceFactory: async (options) => {
+            const db = newDb({ autoCreateForeignKeyIndices: true });
+            const textType = db.public.getType(DataType.text);
+            const uuidType = db.public.getType(DataType.uuid);
+
+            db.public.registerFunction({
+              name: 'version',
+              returns: textType,
+              implementation: () => 'PostgreSQL 13.3',
+            });
+            db.public.registerFunction({
+              name: 'current_database',
+              returns: textType,
+              implementation: () => 'test',
+            });
+            db.public.registerFunction({
+              name: 'uuid_generate_v4',
+              returns: uuidType,
+              implementation: () => randomUUID(),
+              impure: true,
+            });
+
+            const dataSource = await db.adapters
+              .createTypeormDataSource(options)
+              .initialize();
+
+            await dataSource.synchronize();
+            return dataSource;
+          },
+        }),
+        TypeOrmModule.forFeature([Notification]),
+      ],
+      providers: [
+        NotificationsPersistenceService,
+        NotificationsService,
+        {
+          provide: NOTIFICATIONS_GATEWAY_CLIENT,
+          useValue: { emit: emitMock },
+        },
+      ],
+    }).compile();
+
+    service = moduleRef.get(NotificationsService);
+    repository = moduleRef.get(getRepositoryToken(Notification));
+    persistence = moduleRef.get(NotificationsPersistenceService);
+  });
+
+  afterEach(async () => {
+    await moduleRef.close();
+    jest.clearAllMocks();
+  });
+
+  it('persiste notificações de comentários e faz ack quando tudo ocorre bem', async () => {
+    const { context, channel } = createAckContext();
+
+    const taskId = randomUUID();
+    const commentId = randomUUID();
+    const authorId = randomUUID();
+    const firstRecipient = randomUUID();
+    const secondRecipient = randomUUID();
+
+    const payload = {
+      comment: {
+        id: commentId,
+        taskId,
+        authorId,
+        authorName: '  Maria  ',
+        message: 'Um novo comentário',
+        createdAt: new Date('2024-04-01T12:00:00Z').toISOString(),
+        updatedAt: new Date('2024-04-01T12:05:00Z').toISOString(),
+      },
+      recipients: [firstRecipient, secondRecipient, firstRecipient],
+    };
+
+    await service.handleNewComment(payload as never, context);
+
+    const saved = await repository.find({ order: { recipientId: 'ASC' } });
+
+    expect(saved).toHaveLength(2);
+    expect(saved.map((item) => item.recipientId)).toEqual(
+      expect.arrayContaining([firstRecipient, secondRecipient]),
+    );
+    expect(saved[0]).toMatchObject({
+      channel: 'in_app',
+      status: 'pending',
+      message: `Maria comentou na tarefa ${taskId}`,
+      metadata: expect.objectContaining({
+        taskId,
+        commentId,
+        commentAuthorName: 'Maria',
+        commentAuthorId: authorId,
+      }),
+    });
+    expect(channel.ack).toHaveBeenCalledTimes(1);
+    expect(channel.nack).not.toHaveBeenCalled();
+    expect(emitMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('faz nack e não encaminha quando a persistência falha para comentários', async () => {
+    const { context, channel } = createAckContext();
+
+    jest
+      .spyOn(persistence, 'createNotification')
+      .mockRejectedValueOnce(new Error('db indisponível'));
+
+    const taskId = randomUUID();
+    const commentId = randomUUID();
+    const recipientId = randomUUID();
+
+    const payload = {
+      comment: {
+        id: commentId,
+        taskId,
+      },
+      recipients: [recipientId],
+    };
+
+    await service.handleNewComment(payload as never, context);
+
+    expect(channel.ack).not.toHaveBeenCalled();
+    expect(channel.nack).toHaveBeenCalledTimes(1);
+    expect(emitMock).not.toHaveBeenCalled();
+    expect(await repository.count()).toBe(0);
+  });
+
+  it('persiste notificações de atualização de tarefa e realiza ack', async () => {
+    const { context, channel } = createAckContext();
+
+    const taskId = randomUUID();
+    const recipientId = randomUUID();
+    const actorId = randomUUID();
+
+    const payload = {
+      task: {
+        id: taskId,
+        title: ' Revisão de código ',
+      },
+      recipients: [recipientId],
+      actor: {
+        id: actorId,
+        displayName: '  João  ',
+      },
+      changes: [
+        {
+          field: 'status',
+          previousValue: 'todo',
+          currentValue: 'doing',
+        },
+      ],
+    };
+
+    await service.handleTaskUpdated(payload as never, context);
+
+    const saved = await repository.find();
+    expect(saved).toHaveLength(1);
+    expect(saved[0]).toMatchObject({
+      recipientId,
+      message: 'João atualizou a tarefa Revisão de código',
+      metadata: expect.objectContaining({
+        taskId,
+        taskTitle: 'Revisão de código',
+        actorId,
+      }),
+    });
+    expect(channel.ack).toHaveBeenCalledTimes(1);
+    expect(channel.nack).not.toHaveBeenCalled();
+    expect(emitMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('faz nack e cancela encaminhamento quando persistência falha em atualizações de tarefa', async () => {
+    const { context, channel } = createAckContext();
+
+    jest
+      .spyOn(persistence, 'createNotification')
+      .mockRejectedValue(new Error('falha na escrita'));
+
+    const taskId = randomUUID();
+    const recipientId = randomUUID();
+
+    const payload = {
+      task: {
+        id: taskId,
+      },
+      recipients: [recipientId],
+    };
+
+    await service.handleTaskUpdated(payload as never, context);
+
+    expect(channel.ack).not.toHaveBeenCalled();
+    expect(channel.nack).toHaveBeenCalledTimes(1);
+    expect(emitMock).not.toHaveBeenCalled();
+    expect(await repository.count()).toBe(0);
+  });
+
+  it('faz nack quando o gateway falha ao encaminhar o evento', async () => {
+    const { context, channel } = createAckContext();
+
+    emitMock.mockReturnValueOnce(throwError(() => new Error('gateway indisponível')));
+
+    const taskId = randomUUID();
+    const recipientId = randomUUID();
+
+    const payload = {
+      task: {
+        id: taskId,
+      },
+      recipients: [recipientId],
+    };
+
+    await service.handleTaskUpdated(payload as never, context);
+
+    expect(channel.ack).not.toHaveBeenCalled();
+    expect(channel.nack).toHaveBeenCalledTimes(1);
+    expect(await repository.count()).toBe(1);
+  });
+});

--- a/apps/notifications/src/notifications/persistence/notifications-persistence.service.spec.ts
+++ b/apps/notifications/src/notifications/persistence/notifications-persistence.service.spec.ts
@@ -1,0 +1,173 @@
+import type { Repository } from 'typeorm';
+import { NOTIFICATION_STATUSES } from '@repo/types';
+
+import { Notification } from '../notification.entity';
+import { NotificationsPersistenceService } from './notifications-persistence.service';
+
+describe('NotificationsPersistenceService', () => {
+  let repository: jest.Mocked<Partial<Repository<Notification>>>;
+  let service: NotificationsPersistenceService;
+
+  beforeEach(() => {
+    repository = {
+      create: jest.fn(),
+      save: jest.fn(),
+      findOne: jest.fn(),
+      find: jest.fn(),
+    };
+
+    service = new NotificationsPersistenceService(
+      repository as Repository<Notification>,
+    );
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('cria notificações normalizando campos opcionais', async () => {
+    const sentAtIso = new Date('2024-03-01T12:00:00Z').toISOString();
+    const createdNotification: Notification = {
+      id: 'notification-1',
+      recipientId: 'user-1',
+      channel: 'in_app',
+      status: 'pending',
+      message: 'Olá',
+      metadata: null,
+      createdAt: new Date('2024-03-01T12:00:00Z'),
+      sentAt: null,
+    };
+
+    repository.create!.mockReturnValue(createdNotification);
+    repository.save!.mockResolvedValue({
+      ...createdNotification,
+      status: 'sent',
+      sentAt: new Date(sentAtIso),
+    });
+
+    const result = await service.createNotification({
+      recipientId: 'user-1',
+      channel: 'in_app',
+      message: 'Olá',
+      sentAt: sentAtIso,
+    });
+
+    expect(repository.create).toHaveBeenCalledTimes(1);
+    const createPayload = repository.create!.mock.calls[0][0];
+    expect(createPayload).toMatchObject({
+      recipientId: 'user-1',
+      channel: 'in_app',
+      message: 'Olá',
+      metadata: null,
+      status: NOTIFICATION_STATUSES[0],
+    });
+    expect(createPayload.sentAt).toBeInstanceOf(Date);
+    expect(createPayload.sentAt?.toISOString()).toBe(sentAtIso);
+    expect(repository.save).toHaveBeenCalledWith(createdNotification);
+    expect(result.status).toBe('sent');
+    expect(result.sentAt?.toISOString()).toBe(sentAtIso);
+  });
+
+  it('atualiza o status e retorna null quando notificação não existe', async () => {
+    repository.findOne!.mockResolvedValue(null);
+
+    const result = await service.updateNotificationStatus('missing', {
+      status: 'failed',
+    });
+
+    expect(repository.findOne).toHaveBeenCalledWith({ where: { id: 'missing' } });
+    expect(repository.save).not.toHaveBeenCalled();
+    expect(result).toBeNull();
+  });
+
+  it('atualiza o status e data de envio quando a notificação existe', async () => {
+    const existingNotification: Notification = {
+      id: 'notification-2',
+      recipientId: 'user-2',
+      channel: 'email',
+      status: 'pending',
+      message: 'Mensagem',
+      metadata: null,
+      createdAt: new Date('2024-02-15T08:00:00Z'),
+      sentAt: null,
+    };
+
+    repository.findOne!.mockResolvedValue(existingNotification);
+    repository.save!.mockResolvedValue({
+      ...existingNotification,
+      status: 'sent',
+      sentAt: new Date('2024-02-16T10:30:00Z'),
+    });
+
+    const result = await service.updateNotificationStatus('notification-2', {
+      status: 'sent',
+      sentAt: '2024-02-16T10:30:00.000Z',
+    });
+
+    expect(repository.save).toHaveBeenCalledTimes(1);
+    const savedNotification = repository.save!.mock.calls[0][0];
+    expect(savedNotification.status).toBe('sent');
+    expect(savedNotification.sentAt).toBeInstanceOf(Date);
+    expect(savedNotification.sentAt?.toISOString()).toBe(
+      '2024-02-16T10:30:00.000Z',
+    );
+    expect(result?.status).toBe('sent');
+    expect(result?.sentAt?.toISOString()).toBe('2024-02-16T10:30:00.000Z');
+  });
+
+  it('limpa o sentAt quando explicitamente definido como null', async () => {
+    const existingNotification: Notification = {
+      id: 'notification-3',
+      recipientId: 'user-3',
+      channel: 'sms',
+      status: 'sent',
+      message: 'Conteúdo',
+      metadata: null,
+      createdAt: new Date('2024-01-10T05:00:00Z'),
+      sentAt: new Date('2024-01-10T06:00:00Z'),
+    };
+
+    repository.findOne!.mockResolvedValue(existingNotification);
+    repository.save!.mockResolvedValue({
+      ...existingNotification,
+      status: 'failed',
+      sentAt: null,
+    });
+
+    const result = await service.updateNotificationStatus('notification-3', {
+      status: 'failed',
+      sentAt: null,
+    });
+
+    expect(repository.save).toHaveBeenCalledTimes(1);
+    const savedNotification = repository.save!.mock.calls[0][0];
+    expect(savedNotification.status).toBe('failed');
+    expect(savedNotification.sentAt).toBeNull();
+    expect(result?.sentAt).toBeNull();
+  });
+
+  it('busca notificações por destinatário ordenando do mais recente para o mais antigo', async () => {
+    const notifications: Notification[] = [
+      {
+        id: 'notification-10',
+        recipientId: 'user-10',
+        channel: 'in_app',
+        status: 'pending',
+        message: 'Primeira',
+        metadata: null,
+        createdAt: new Date('2024-04-01T09:00:00Z'),
+        sentAt: null,
+      },
+    ];
+
+    repository.find!.mockResolvedValue(notifications);
+
+    const result = await service.findByRecipient('user-10');
+
+    expect(repository.find).toHaveBeenCalledWith({
+      where: { recipientId: 'user-10' },
+      order: { createdAt: 'DESC' },
+    });
+    expect(result).toBe(notifications);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -416,6 +416,9 @@ importers:
       jest:
         specifier: ^30.0.0
         version: 30.2.0(@types/node@22.15.3)(ts-node@10.9.2(@types/node@22.15.3)(typescript@5.9.2))
+      pg-mem:
+        specifier: ^3.0.5
+        version: 3.0.5(typeorm@0.3.27(pg@8.16.3)(reflect-metadata@0.2.2)(sql.js@1.13.0)(ts-node@10.9.2(@types/node@22.15.3)(typescript@5.9.2)))
       prettier:
         specifier: ^3.4.2
         version: 3.6.2


### PR DESCRIPTION
## Summary
- add unit tests for the notifications persistence service to validate field normalization, status updates, and queries
- add integration tests for notifications event handlers exercising persistence, gateway forwarding, and ack/nack flows via an in-memory database
- include pg-mem as a dev dependency to support the in-memory Postgres setup used by the new integration tests

## Testing
- pnpm --filter @apps/notifications-service test

------
https://chatgpt.com/codex/tasks/task_e_68e72953d85c832b926b3be375ebdbdb