### PR TITLE
feat: enable structured logging across microservices

### DIFF
--- a/apps/auth/src/app.module.ts
+++ b/apps/auth/src/app.module.ts
@@ -5,6 +5,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { UsersModule } from './users/users.module';
 import { User } from './users/entities/user.entity';
 import { AuthModule } from './auth/auth.module';
+import { LoggingModule } from './common/logging/logging.module';
 
 const validateEnv = (config: Record<string, unknown>) => {
   const databaseUrl = config['DATABASE_URL'];
@@ -18,6 +19,7 @@ const validateEnv = (config: Record<string, unknown>) => {
 
 @Module({
   imports: [
+    LoggingModule,
     HealthModule,
     ConfigModule.forRoot({
       isGlobal: true,

--- a/apps/auth/src/common/logging/logging.module.ts
+++ b/apps/auth/src/common/logging/logging.module.ts
@@ -1,0 +1,23 @@
+import { Global, Module, Logger } from '@nestjs/common';
+
+import { AppLoggerService, createAppLogger } from '@repo/logger';
+
+import { RpcContextInterceptor } from './rpc-context.interceptor';
+
+@Global()
+@Module({
+  providers: [
+    {
+      provide: AppLoggerService,
+      useFactory: () =>
+        createAppLogger({ name: 'auth-service' }).withContext({ service: 'auth-service' }),
+    },
+    {
+      provide: Logger,
+      useExisting: AppLoggerService,
+    },
+    RpcContextInterceptor,
+  ],
+  exports: [AppLoggerService, Logger, RpcContextInterceptor],
+})
+export class LoggingModule {}

--- a/apps/auth/src/common/logging/rpc-context.interceptor.ts
+++ b/apps/auth/src/common/logging/rpc-context.interceptor.ts
@@ -1,0 +1,72 @@
+import type { CallHandler, ExecutionContext } from '@nestjs/common';
+import { Injectable, NestInterceptor } from '@nestjs/common';
+import type { RmqContext } from '@nestjs/microservices';
+import type { Observable } from 'rxjs';
+
+import { runWithRequestContext, type RequestContext } from '@repo/logger';
+
+const REQUEST_ID_HEADER = 'x-request-id';
+
+const extractRequestContext = (message: unknown): RequestContext | undefined => {
+  if (
+    !message ||
+    typeof message !== 'object' ||
+    !('properties' in message) ||
+    typeof (message as { properties?: unknown }).properties !== 'object'
+  ) {
+    return undefined;
+  }
+
+  const properties = (message as {
+    properties?: {
+      headers?: Record<string, unknown>;
+      correlationId?: unknown;
+      messageId?: unknown;
+    };
+  }).properties;
+
+  if (!properties) {
+    return undefined;
+  }
+
+  const headers = properties.headers ?? {};
+  const requestIdCandidate = headers[REQUEST_ID_HEADER] ?? headers['request-id'];
+  const correlationIdCandidate = properties.correlationId ?? headers['x-correlation-id'];
+  const messageIdCandidate = properties.messageId;
+
+  const requestContext: RequestContext = {};
+
+  if (typeof requestIdCandidate === 'string' && requestIdCandidate.trim().length > 0) {
+    requestContext.requestId = requestIdCandidate;
+  }
+
+  if (typeof correlationIdCandidate === 'string' && correlationIdCandidate.trim().length > 0) {
+    requestContext.correlationId = correlationIdCandidate;
+  }
+
+  if (typeof messageIdCandidate === 'string' && messageIdCandidate.trim().length > 0) {
+    requestContext.messageId = messageIdCandidate;
+  }
+
+  return Object.keys(requestContext).length > 0 ? requestContext : undefined;
+};
+
+@Injectable()
+export class RpcContextInterceptor implements NestInterceptor {
+  intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
+    const contextType = context.getType<'rmq'>();
+    if (contextType !== 'rpc' && contextType !== 'rmq') {
+      return next.handle();
+    }
+
+    const rmqContext = context.switchToRpc().getContext<RmqContext>();
+    const message = rmqContext?.getMessage?.();
+    const requestContext = extractRequestContext(message);
+
+    if (!requestContext) {
+      return next.handle();
+    }
+
+    return runWithRequestContext(requestContext, () => next.handle());
+  }
+}

--- a/apps/auth/src/database/wait-for-database.ts
+++ b/apps/auth/src/database/wait-for-database.ts
@@ -1,18 +1,22 @@
-import { Logger } from '@nestjs/common';
 import {
   resolveWaitForDatabaseOptions as sharedResolveWaitForDatabaseOptions,
   waitForDatabase as sharedWaitForDatabase,
   type ResolvedWaitForDatabaseOptions as SharedResolvedWaitForDatabaseOptions,
   type WaitForDatabaseOptions as SharedWaitForDatabaseOptions,
 } from '@repo/types/utils/database';
+import { createAppLogger, type StructuredLogger } from '@repo/logger';
 
-const logger = new Logger('DatabaseBootstrap');
+const defaultLogger = createAppLogger({ name: 'auth-service' }).withContext({
+  service: 'auth-service',
+  context: 'wait-for-database',
+});
 
 export type WaitForDatabaseOptions = SharedWaitForDatabaseOptions;
 export type ResolvedWaitForDatabaseOptions = SharedResolvedWaitForDatabaseOptions;
 
 export const waitForDatabase = async (
   options: SharedWaitForDatabaseOptions,
+  logger: StructuredLogger = defaultLogger,
 ): Promise<void> => {
   await sharedWaitForDatabase({
     ...options,

--- a/apps/notifications/src/app.module.ts
+++ b/apps/notifications/src/app.module.ts
@@ -11,6 +11,7 @@ import { HealthModule } from './health/health.module';
 import { NotificationsService } from './notifications.service';
 import { Notification } from './notifications/notification.entity';
 import { NotificationsPersistenceModule } from './notifications/persistence/notifications-persistence.module';
+import { LoggingModule } from './common/logging/logging.module';
 
 const validateEnv = (config: Record<string, unknown>) => {
   const databaseUrl = config['DATABASE_URL'];
@@ -24,6 +25,7 @@ const validateEnv = (config: Record<string, unknown>) => {
 
 @Module({
   imports: [
+    LoggingModule,
     ConfigModule.forRoot({
       isGlobal: true,
       envFilePath: ['.env'],

--- a/apps/notifications/src/common/logging/logging.module.ts
+++ b/apps/notifications/src/common/logging/logging.module.ts
@@ -1,0 +1,25 @@
+import { Global, Module, Logger } from '@nestjs/common';
+
+import { AppLoggerService, createAppLogger } from '@repo/logger';
+
+import { RpcContextInterceptor } from './rpc-context.interceptor';
+
+@Global()
+@Module({
+  providers: [
+    {
+      provide: AppLoggerService,
+      useFactory: () =>
+        createAppLogger({ name: 'notifications-service' }).withContext({
+          service: 'notifications-service',
+        }),
+    },
+    {
+      provide: Logger,
+      useExisting: AppLoggerService,
+    },
+    RpcContextInterceptor,
+  ],
+  exports: [AppLoggerService, Logger, RpcContextInterceptor],
+})
+export class LoggingModule {}

--- a/apps/notifications/src/common/logging/rpc-context.interceptor.ts
+++ b/apps/notifications/src/common/logging/rpc-context.interceptor.ts
@@ -1,0 +1,72 @@
+import type { CallHandler, ExecutionContext } from '@nestjs/common';
+import { Injectable, NestInterceptor } from '@nestjs/common';
+import type { RmqContext } from '@nestjs/microservices';
+import type { Observable } from 'rxjs';
+
+import { runWithRequestContext, type RequestContext } from '@repo/logger';
+
+const REQUEST_ID_HEADER = 'x-request-id';
+
+const extractRequestContext = (message: unknown): RequestContext | undefined => {
+  if (
+    !message ||
+    typeof message !== 'object' ||
+    !('properties' in message) ||
+    typeof (message as { properties?: unknown }).properties !== 'object'
+  ) {
+    return undefined;
+  }
+
+  const properties = (message as {
+    properties?: {
+      headers?: Record<string, unknown>;
+      correlationId?: unknown;
+      messageId?: unknown;
+    };
+  }).properties;
+
+  if (!properties) {
+    return undefined;
+  }
+
+  const headers = properties.headers ?? {};
+  const requestIdCandidate = headers[REQUEST_ID_HEADER] ?? headers['request-id'];
+  const correlationIdCandidate = properties.correlationId ?? headers['x-correlation-id'];
+  const messageIdCandidate = properties.messageId;
+
+  const requestContext: RequestContext = {};
+
+  if (typeof requestIdCandidate === 'string' && requestIdCandidate.trim().length > 0) {
+    requestContext.requestId = requestIdCandidate;
+  }
+
+  if (typeof correlationIdCandidate === 'string' && correlationIdCandidate.trim().length > 0) {
+    requestContext.correlationId = correlationIdCandidate;
+  }
+
+  if (typeof messageIdCandidate === 'string' && messageIdCandidate.trim().length > 0) {
+    requestContext.messageId = messageIdCandidate;
+  }
+
+  return Object.keys(requestContext).length > 0 ? requestContext : undefined;
+};
+
+@Injectable()
+export class RpcContextInterceptor implements NestInterceptor {
+  intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
+    const contextType = context.getType<'rmq'>();
+    if (contextType !== 'rpc' && contextType !== 'rmq') {
+      return next.handle();
+    }
+
+    const rmqContext = context.switchToRpc().getContext<RmqContext>();
+    const message = rmqContext?.getMessage?.();
+    const requestContext = extractRequestContext(message);
+
+    if (!requestContext) {
+      return next.handle();
+    }
+
+    return runWithRequestContext(requestContext, () => next.handle());
+  }
+}

--- a/apps/tasks/src/app.module.ts
+++ b/apps/tasks/src/app.module.ts
@@ -5,6 +5,7 @@ import { HealthModule } from './health/health.module';
 import { TasksModule } from './tasks/tasks.module';
 import { Task } from './tasks/task.entity';
 import { Comment } from './comments/comment.entity';
+import { LoggingModule } from './common/logging/logging.module';
 
 const validateEnv = (config: Record<string, unknown>) => {
   const databaseUrl = config['DATABASE_URL'];
@@ -18,6 +19,7 @@ const validateEnv = (config: Record<string, unknown>) => {
 
 @Module({
   imports: [
+    LoggingModule,
     ConfigModule.forRoot({
       isGlobal: true,
       envFilePath: ['.env'],

--- a/apps/tasks/src/common/logging/logging.module.ts
+++ b/apps/tasks/src/common/logging/logging.module.ts
@@ -1,0 +1,23 @@
+import { Global, Module, Logger } from '@nestjs/common';
+
+import { AppLoggerService, createAppLogger } from '@repo/logger';
+
+import { RpcContextInterceptor } from './rpc-context.interceptor';
+
+@Global()
+@Module({
+  providers: [
+    {
+      provide: AppLoggerService,
+      useFactory: () =>
+        createAppLogger({ name: 'tasks-service' }).withContext({ service: 'tasks-service' }),
+    },
+    {
+      provide: Logger,
+      useExisting: AppLoggerService,
+    },
+    RpcContextInterceptor,
+  ],
+  exports: [AppLoggerService, Logger, RpcContextInterceptor],
+})
+export class LoggingModule {}

--- a/apps/tasks/src/common/logging/rpc-context.interceptor.ts
+++ b/apps/tasks/src/common/logging/rpc-context.interceptor.ts
@@ -1,0 +1,72 @@
+import type { CallHandler, ExecutionContext } from '@nestjs/common';
+import { Injectable, NestInterceptor } from '@nestjs/common';
+import type { RmqContext } from '@nestjs/microservices';
+import type { Observable } from 'rxjs';
+
+import { runWithRequestContext, type RequestContext } from '@repo/logger';
+
+const REQUEST_ID_HEADER = 'x-request-id';
+
+const extractRequestContext = (message: unknown): RequestContext | undefined => {
+  if (
+    !message ||
+    typeof message !== 'object' ||
+    !('properties' in message) ||
+    typeof (message as { properties?: unknown }).properties !== 'object'
+  ) {
+    return undefined;
+  }
+
+  const properties = (message as {
+    properties?: {
+      headers?: Record<string, unknown>;
+      correlationId?: unknown;
+      messageId?: unknown;
+    };
+  }).properties;
+
+  if (!properties) {
+    return undefined;
+  }
+
+  const headers = properties.headers ?? {};
+  const requestIdCandidate = headers[REQUEST_ID_HEADER] ?? headers['request-id'];
+  const correlationIdCandidate = properties.correlationId ?? headers['x-correlation-id'];
+  const messageIdCandidate = properties.messageId;
+
+  const requestContext: RequestContext = {};
+
+  if (typeof requestIdCandidate === 'string' && requestIdCandidate.trim().length > 0) {
+    requestContext.requestId = requestIdCandidate;
+  }
+
+  if (typeof correlationIdCandidate === 'string' && correlationIdCandidate.trim().length > 0) {
+    requestContext.correlationId = correlationIdCandidate;
+  }
+
+  if (typeof messageIdCandidate === 'string' && messageIdCandidate.trim().length > 0) {
+    requestContext.messageId = messageIdCandidate;
+  }
+
+  return Object.keys(requestContext).length > 0 ? requestContext : undefined;
+};
+
+@Injectable()
+export class RpcContextInterceptor implements NestInterceptor {
+  intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
+    const contextType = context.getType<'rmq'>();
+    if (contextType !== 'rpc' && contextType !== 'rmq') {
+      return next.handle();
+    }
+
+    const rmqContext = context.switchToRpc().getContext<RmqContext>();
+    const message = rmqContext?.getMessage?.();
+    const requestContext = extractRequestContext(message);
+
+    if (!requestContext) {
+      return next.handle();
+    }
+
+    return runWithRequestContext(requestContext, () => next.handle());
+  }
+}

--- a/apps/tasks/src/database/wait-for-database.ts
+++ b/apps/tasks/src/database/wait-for-database.ts
@@ -1,18 +1,22 @@
-import { Logger } from '@nestjs/common';
 import {
   resolveWaitForDatabaseOptions as sharedResolveWaitForDatabaseOptions,
   waitForDatabase as sharedWaitForDatabase,
   type ResolvedWaitForDatabaseOptions as SharedResolvedWaitForDatabaseOptions,
   type WaitForDatabaseOptions as SharedWaitForDatabaseOptions,
 } from '@repo/types/utils/database';
+import { createAppLogger, type StructuredLogger } from '@repo/logger';
 
-const logger = new Logger('TasksDatabaseBootstrap');
+const defaultLogger = createAppLogger({ name: 'tasks-service' }).withContext({
+  service: 'tasks-service',
+  context: 'wait-for-database',
+});
 
 export type WaitForDatabaseOptions = SharedWaitForDatabaseOptions;
 export type ResolvedWaitForDatabaseOptions = SharedResolvedWaitForDatabaseOptions;
 
 export const waitForDatabase = async (
   options: SharedWaitForDatabaseOptions,
+  logger: StructuredLogger = defaultLogger,
 ): Promise<void> => {
   await sharedWaitForDatabase({
     ...options,


### PR DESCRIPTION
## Summary
- add dedicated logging modules to the auth, tasks, and notifications services with AppLoggerService provided globally
- wire structured logging into each microservice bootstrap and rabbitmq context interceptor to capture request metadata
- update wait-for-database helpers and notifications service logging to use the shared structured logger API

## Testing
- pnpm lint *(fails: ESLint 9 expects an eslint.config.js in @repo/logger)*

------
https://chatgpt.com/codex/tasks/task_e_68e7295b7864832bacbc9e30567cf728