### PR TITLE
Fix logger module resolution and RMQ record types

### DIFF
--- a/apps/api/tsconfig.build.json
+++ b/apps/api/tsconfig.build.json
@@ -3,7 +3,9 @@
   "compilerOptions": {
     "paths": {
       "@repo/types": ["../../packages/types/dist/index.d.ts"],
-      "@repo/types/*": ["../../packages/types/dist/*.d.ts"]
+      "@repo/types/*": ["../../packages/types/dist/*.d.ts"],
+      "@repo/logger": ["../../packages/logger/src/index.ts"],
+      "@repo/logger/*": ["../../packages/logger/src/*.ts"]
     }
   },
   "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -22,6 +22,12 @@
       "@repo/types/*": [
         "../../packages/types/dist-cjs/*.js",
         "../../packages/types/dist/*.d.ts"
+      ],
+      "@repo/logger": [
+        "../../packages/logger/src/index.ts"
+      ],
+      "@repo/logger/*": [
+        "../../packages/logger/src/*.ts"
       ]
     },
     "incremental": true,

--- a/apps/auth/src/common/logging/rpc-context.interceptor.ts
+++ b/apps/auth/src/common/logging/rpc-context.interceptor.ts
@@ -54,8 +54,8 @@ const extractRequestContext = (message: unknown): RequestContext | undefined => 
 @Injectable()
 export class RpcContextInterceptor implements NestInterceptor {
   intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
-    const contextType = context.getType<'rmq'>();
-    if (contextType !== 'rpc' && contextType !== 'rmq') {
+    const contextType = context.getType();
+    if (contextType !== 'rpc') {
       return next.handle();
     }
 

--- a/apps/auth/tsconfig.build.json
+++ b/apps/auth/tsconfig.build.json
@@ -3,7 +3,9 @@
   "compilerOptions": {
     "paths": {
       "@repo/types": ["../../packages/types/dist/index.d.ts"],
-      "@repo/types/*": ["../../packages/types/dist/*.d.ts"]
+      "@repo/types/*": ["../../packages/types/dist/*.d.ts"],
+      "@repo/logger": ["../../packages/logger/src/index.ts"],
+      "@repo/logger/*": ["../../packages/logger/src/*.ts"]
     }
   },
   "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]

--- a/apps/auth/tsconfig.json
+++ b/apps/auth/tsconfig.json
@@ -22,6 +22,12 @@
       "@repo/types/*": [
         "../../packages/types/dist-cjs/*.js",
         "../../packages/types/dist/*.d.ts"
+      ],
+      "@repo/logger": [
+        "../../packages/logger/src/index.ts"
+      ],
+      "@repo/logger/*": [
+        "../../packages/logger/src/*.ts"
       ]
     },
     "incremental": true,

--- a/apps/notifications/src/common/logging/rpc-context.interceptor.ts
+++ b/apps/notifications/src/common/logging/rpc-context.interceptor.ts
@@ -54,8 +54,8 @@ const extractRequestContext = (message: unknown): RequestContext | undefined => 
 @Injectable()
 export class RpcContextInterceptor implements NestInterceptor {
   intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
-    const contextType = context.getType<'rmq'>();
-    if (contextType !== 'rpc' && contextType !== 'rmq') {
+    const contextType = context.getType();
+    if (contextType !== 'rpc') {
       return next.handle();
     }
 

--- a/apps/notifications/src/notifications.service.ts
+++ b/apps/notifications/src/notifications.service.ts
@@ -4,6 +4,7 @@ import {
   EventPattern,
   Payload,
   RmqContext,
+  RmqRecord,
   RmqRecordBuilder,
 } from '@nestjs/microservices';
 import {
@@ -384,13 +385,13 @@ export class NotificationsService {
   private createGatewayRecord<TPayload extends object>(
     payload: TPayload,
     requestId?: string,
-  ): ReturnType<RmqRecordBuilder['build']> {
+  ): RmqRecord<TPayload> {
     const { correlatedPayload, resolvedRequestId } = this.withRequestId(
       payload,
       requestId,
     );
 
-    const builder = new RmqRecordBuilder(correlatedPayload);
+    const builder = new RmqRecordBuilder<TPayload>(correlatedPayload);
 
     if (resolvedRequestId) {
       builder.setOptions({

--- a/apps/notifications/tsconfig.build.json
+++ b/apps/notifications/tsconfig.build.json
@@ -3,7 +3,9 @@
   "compilerOptions": {
     "paths": {
       "@repo/types": ["../../packages/types/dist/index.d.ts"],
-      "@repo/types/*": ["../../packages/types/dist/*.d.ts"]
+      "@repo/types/*": ["../../packages/types/dist/*.d.ts"],
+      "@repo/logger": ["../../packages/logger/src/index.ts"],
+      "@repo/logger/*": ["../../packages/logger/src/*.ts"]
     }
   },
   "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]

--- a/apps/tasks/src/comments/comments.service.ts
+++ b/apps/tasks/src/comments/comments.service.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { ClientProxy, RmqRecordBuilder } from '@nestjs/microservices';
+import { ClientProxy, RmqRecord, RmqRecordBuilder } from '@nestjs/microservices';
 import { defaultIfEmpty, lastValueFrom } from 'rxjs';
 import { Repository, type DeepPartial } from 'typeorm';
 import { Comment } from './comment.entity';
@@ -133,9 +133,9 @@ export class CommentsService {
 
   private createEventRecord<TPayload extends object>(
     payload: TPayload,
-  ): ReturnType<RmqRecordBuilder['build']> {
+  ): RmqRecord<TPayload> {
     const { correlatedPayload, requestId } = this.withRequestId(payload);
-    const builder = new RmqRecordBuilder(correlatedPayload);
+    const builder = new RmqRecordBuilder<TPayload>(correlatedPayload);
 
     if (requestId) {
       builder.setOptions({

--- a/apps/tasks/src/common/logging/rpc-context.interceptor.ts
+++ b/apps/tasks/src/common/logging/rpc-context.interceptor.ts
@@ -54,8 +54,8 @@ const extractRequestContext = (message: unknown): RequestContext | undefined => 
 @Injectable()
 export class RpcContextInterceptor implements NestInterceptor {
   intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
-    const contextType = context.getType<'rmq'>();
-    if (contextType !== 'rpc' && contextType !== 'rmq') {
+    const contextType = context.getType();
+    if (contextType !== 'rpc') {
       return next.handle();
     }
 

--- a/apps/tasks/src/tasks/tasks.service.ts
+++ b/apps/tasks/src/tasks/tasks.service.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { ClientProxy, RmqRecordBuilder } from '@nestjs/microservices';
+import { ClientProxy, RmqRecord, RmqRecordBuilder } from '@nestjs/microservices';
 import { defaultIfEmpty, lastValueFrom } from 'rxjs';
 import { Repository, type DeepPartial } from 'typeorm';
 import { Task } from './task.entity';
@@ -234,9 +234,9 @@ export class TasksService {
 
   private createEventRecord<TPayload extends object>(
     payload: TPayload,
-  ): ReturnType<RmqRecordBuilder['build']> {
+  ): RmqRecord<TPayload> {
     const { correlatedPayload, requestId } = this.withRequestId(payload);
-    const builder = new RmqRecordBuilder(correlatedPayload);
+    const builder = new RmqRecordBuilder<TPayload>(correlatedPayload);
 
     if (requestId) {
       builder.setOptions({

--- a/apps/tasks/tsconfig.build.json
+++ b/apps/tasks/tsconfig.build.json
@@ -9,6 +9,12 @@
       "@repo/types/*": [
         "../../packages/types/dist-cjs/*.js",
         "../../packages/types/dist/*.d.ts"
+      ],
+      "@repo/logger": [
+        "../../packages/logger/src/index.ts"
+      ],
+      "@repo/logger/*": [
+        "../../packages/logger/src/*.ts"
       ]
     }
   },

--- a/apps/tasks/tsconfig.json
+++ b/apps/tasks/tsconfig.json
@@ -22,6 +22,12 @@
       "@repo/types/*": [
         "../../packages/types/dist-cjs/*.js",
         "../../packages/types/dist/*.d.ts"
+      ],
+      "@repo/logger": [
+        "../../packages/logger/src/index.ts"
+      ],
+      "@repo/logger/*": [
+        "../../packages/logger/src/*.ts"
       ]
     },
     "incremental": true,

--- a/packages/typescript-config/base.json
+++ b/packages/typescript-config/base.json
@@ -17,7 +17,9 @@
     "strict": true,
     "paths": {
       "@repo/types": ["../types/src/index.ts"],
-      "@repo/types/*": ["../types/src/*"]
+      "@repo/types/*": ["../types/src/*"],
+      "@repo/logger": ["../logger/dist/index.d.ts"],
+      "@repo/logger/*": ["../logger/dist/*.d.ts"]
     },
     "target": "ES2022"
   }


### PR DESCRIPTION
## Summary
- add @repo/logger path aliases to each service tsconfig and the shared base config so TypeScript resolves the logger package
- adjust RPC context interceptors and RMQ record builders to use valid NestJS types and preserve correlated payload metadata

## Testing
- pnpm turbo run build --filter=@apps/api-gateway --filter=@apps/auth-service --filter=@apps/tasks-service --filter=@apps/notifications-service

------
https://chatgpt.com/codex/tasks/task_e_68e739be7544832b9b75d0ebafc7f3d9