### PR TITLE
feat(web): add notifications popover to tasks page

### DIFF
--- a/apps/web/src/features/notifications/api/getNotifications.ts
+++ b/apps/web/src/features/notifications/api/getNotifications.ts
@@ -1,0 +1,87 @@
+import type {
+  NotificationChannel,
+  NotificationDTO,
+  NotificationStatus,
+  PaginatedResponse,
+} from '@repo/types'
+
+import { API_BASE_URL, fetchWithAuth } from '@/lib/apiClient'
+import { paginatedResponseSchema } from '@/schemas/paginatedResponse'
+
+import { notificationSchema } from '../schemas/notificationSchema'
+
+const NOTIFICATIONS_ENDPOINT = API_BASE_URL
+  ? `${API_BASE_URL}/notifications`
+  : '/api/notifications'
+
+const paginatedNotificationsSchema = paginatedResponseSchema(notificationSchema)
+
+export interface GetNotificationsFilters {
+  status?: NotificationStatus
+  channel?: NotificationChannel
+  search?: string | null
+  from?: string | null
+  to?: string | null
+  page?: number
+  limit?: number
+}
+
+function buildNotificationsUrl(filters?: GetNotificationsFilters) {
+  const params = new URLSearchParams()
+
+  if (filters?.page) {
+    params.set('page', filters.page.toString())
+  }
+
+  if (filters?.limit) {
+    params.set('limit', filters.limit.toString())
+  }
+
+  if (filters?.status) {
+    params.set('status', filters.status)
+  }
+
+  if (filters?.channel) {
+    params.set('channel', filters.channel)
+  }
+
+  const searchTerm = filters?.search?.trim()
+  if (searchTerm) {
+    params.set('search', searchTerm)
+  }
+
+  if (filters?.from) {
+    params.set('from', filters.from)
+  }
+
+  if (filters?.to) {
+    params.set('to', filters.to)
+  }
+
+  const query = params.toString()
+
+  return query
+    ? `${NOTIFICATIONS_ENDPOINT}?${query}`
+    : NOTIFICATIONS_ENDPOINT
+}
+
+export async function getNotifications(
+  filters?: GetNotificationsFilters,
+): Promise<PaginatedResponse<NotificationDTO>> {
+  const response = await fetchWithAuth(buildNotificationsUrl(filters), {
+    method: 'GET',
+  })
+
+  if (!response.ok) {
+    throw new Error(
+      `Falha ao carregar notificações: ${response.status} ${response.statusText}`,
+    )
+  }
+
+  const data = await response.json()
+  const parsed = paginatedNotificationsSchema.parse(data)
+
+  return parsed
+}
+
+export { NOTIFICATIONS_ENDPOINT }

--- a/apps/web/src/features/notifications/components/NotificationsPopover.tsx
+++ b/apps/web/src/features/notifications/components/NotificationsPopover.tsx
@@ -1,0 +1,251 @@
+import { useEffect, useMemo, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import type { NotificationDTO } from '@repo/types'
+import { Bell, Loader2 } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { cn } from '@/lib/utils'
+import { router } from '@/router'
+
+import { getNotifications } from '../api/getNotifications'
+
+const REFRESH_INTERVAL_MS = 60_000
+const DEFAULT_LIMIT = 10
+
+const dateFormatter = new Intl.DateTimeFormat('pt-BR', {
+  dateStyle: 'short',
+  timeStyle: 'short',
+})
+
+function formatDateTime(value?: string | null) {
+  if (!value) {
+    return 'Data indisponível'
+  }
+
+  const date = new Date(value)
+
+  if (Number.isNaN(date.getTime())) {
+    return 'Data inválida'
+  }
+
+  return dateFormatter.format(date)
+}
+
+function getTaskIdFromMetadata(notification: NotificationDTO) {
+  const metadata = notification.metadata
+
+  if (metadata && typeof metadata === 'object' && 'taskId' in metadata) {
+    const taskId = metadata.taskId
+
+    if (typeof taskId === 'string' && taskId.trim().length > 0) {
+      return taskId
+    }
+  }
+
+  return null
+}
+
+function formatChannel(channel: NotificationDTO['channel']) {
+  switch (channel) {
+    case 'in_app':
+      return 'In-app'
+    case 'sms':
+      return 'SMS'
+    case 'push':
+      return 'Push'
+    case 'email':
+    default:
+      return 'E-mail'
+  }
+}
+
+function formatStatus(status: NotificationDTO['status']) {
+  switch (status) {
+    case 'pending':
+      return 'Pendente'
+    case 'sent':
+      return 'Enviada'
+    case 'failed':
+      return 'Falhou'
+    default:
+      return status
+  }
+}
+
+interface NotificationsPopoverProps {
+  className?: string
+}
+
+export function NotificationsPopover({ className }: NotificationsPopoverProps) {
+  const [isOpen, setIsOpen] = useState(false)
+
+  const notificationsQuery = useQuery({
+    queryKey: ['notifications', { limit: DEFAULT_LIMIT }],
+    queryFn: () =>
+      getNotifications({
+        channel: 'in_app',
+        limit: DEFAULT_LIMIT,
+        page: 1,
+      }),
+    staleTime: REFRESH_INTERVAL_MS,
+    refetchInterval: REFRESH_INTERVAL_MS,
+    refetchOnWindowFocus: false,
+  })
+
+  const notifications = notificationsQuery.data?.data ?? []
+  const totalNotifications = notificationsQuery.data?.meta.total ?? notifications.length
+  const hasNotifications = totalNotifications > 0
+  const badgeCount = useMemo(() => {
+    if (!hasNotifications) {
+      return null
+    }
+
+    if (totalNotifications > 99) {
+      return '99+'
+    }
+
+    return totalNotifications.toString()
+  }, [hasNotifications, totalNotifications])
+
+  const errorMessage = notificationsQuery.isError
+    ? notificationsQuery.error instanceof Error
+      ? notificationsQuery.error.message
+      : 'Não foi possível carregar as notificações. Tente novamente.'
+    : null
+
+  useEffect(() => {
+    if (!isOpen) {
+      return
+    }
+
+    void notificationsQuery.refetch()
+  }, [isOpen, notificationsQuery])
+
+  return (
+    <Popover open={isOpen} onOpenChange={setIsOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className={cn('relative', className)}
+          aria-label={
+            hasNotifications
+              ? `Você tem ${totalNotifications} notificações`
+              : 'Nenhuma notificação disponível'
+          }
+        >
+          <Bell aria-hidden="true" />
+
+          {badgeCount ? (
+            <span className="absolute -top-1.5 -right-1.5 inline-flex min-h-5 min-w-5 items-center justify-center rounded-full bg-destructive px-1 text-[10px] font-semibold text-destructive-foreground">
+              {badgeCount}
+            </span>
+          ) : null}
+        </Button>
+      </PopoverTrigger>
+
+      <PopoverContent className="w-80 p-0" align="end">
+        <header className="flex items-center justify-between border-b border-border px-4 py-3">
+          <div className="flex items-center gap-2 text-sm font-semibold text-foreground">
+            <Bell className="size-4" aria-hidden="true" />
+            <span>Notificações</span>
+          </div>
+
+          {notificationsQuery.isFetching ? (
+            <span className="flex items-center gap-1 text-xs text-muted-foreground">
+              <Loader2 className="size-3.5 animate-spin" aria-hidden="true" />
+              Atualizando
+            </span>
+          ) : (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="-mr-2 text-xs"
+              onClick={() => notificationsQuery.refetch()}
+            >
+              Atualizar
+            </Button>
+          )}
+        </header>
+
+        <div className="max-h-80 overflow-y-auto">
+          {notificationsQuery.isPending ? (
+            <div className="flex flex-col items-center justify-center gap-2 px-4 py-8 text-sm text-muted-foreground">
+              <Loader2 className="size-5 animate-spin" aria-hidden="true" />
+              <span>Carregando notificações...</span>
+            </div>
+          ) : errorMessage ? (
+            <div className="flex flex-col items-center gap-3 px-4 py-6 text-center">
+              <p className="text-sm text-destructive">{errorMessage}</p>
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                onClick={() => notificationsQuery.refetch()}
+              >
+                Tentar novamente
+              </Button>
+            </div>
+          ) : notifications.length > 0 ? (
+            <ul className="divide-y divide-border">
+              {notifications.map((notification) => {
+                const taskId = getTaskIdFromMetadata(notification)
+
+                return (
+                  <li key={notification.id} className="space-y-2 px-4 py-3 text-sm">
+                    <div className="flex items-start justify-between gap-2">
+                      <p className="font-medium text-foreground">
+                        {notification.message}
+                      </p>
+                      <span className="rounded-full bg-secondary px-2 py-0.5 text-[11px] font-medium uppercase tracking-wide text-secondary-foreground">
+                        {formatChannel(notification.channel)}
+                      </span>
+                    </div>
+
+                    <div className="flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
+                      <span>{formatDateTime(notification.createdAt)}</span>
+                      <span className="font-medium uppercase">
+                        {formatStatus(notification.status)}
+                      </span>
+                    </div>
+
+                    {taskId ? (
+                      <Button
+                        type="button"
+                        variant="link"
+                        size="sm"
+                        className="h-auto px-0 text-xs"
+                        onClick={() => {
+                          void router.navigate({
+                            to: '/tasks/$taskId',
+                            params: { taskId },
+                          })
+                          setIsOpen(false)
+                        }}
+                      >
+                        Ver tarefa
+                      </Button>
+                    ) : null}
+                  </li>
+                )
+              })}
+            </ul>
+          ) : (
+            <div className="px-4 py-8 text-center text-sm text-muted-foreground">
+              Você está em dia! Nenhuma notificação encontrada.
+            </div>
+          )}
+        </div>
+
+        <footer className="border-t border-border px-4 py-2 text-xs text-muted-foreground">
+          {hasNotifications
+            ? `Mostrando ${notifications.length} de ${totalNotifications} notificações`
+            : 'Sem notificações registradas até o momento.'}
+        </footer>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/apps/web/src/features/notifications/schemas/notificationSchema.ts
+++ b/apps/web/src/features/notifications/schemas/notificationSchema.ts
@@ -1,0 +1,25 @@
+import { NOTIFICATION_CHANNELS, NOTIFICATION_STATUSES } from '@repo/types'
+import { z } from 'zod'
+
+const channelValues = [...NOTIFICATION_CHANNELS] as [
+  (typeof NOTIFICATION_CHANNELS)[number],
+  ...(typeof NOTIFICATION_CHANNELS)[number][],
+]
+
+const statusValues = [...NOTIFICATION_STATUSES] as [
+  (typeof NOTIFICATION_STATUSES)[number],
+  ...(typeof NOTIFICATION_STATUSES)[number][],
+]
+
+export const notificationSchema = z.object({
+  id: z.string(),
+  recipientId: z.string(),
+  channel: z.enum(channelValues),
+  status: z.enum(statusValues),
+  message: z.string(),
+  metadata: z.record(z.unknown()).nullish(),
+  createdAt: z.string(),
+  sentAt: z.string().nullish(),
+})
+
+export type NotificationSchema = z.infer<typeof notificationSchema>

--- a/apps/web/src/features/tasks/pages/TasksPage.tsx
+++ b/apps/web/src/features/tasks/pages/TasksPage.tsx
@@ -12,6 +12,8 @@ import { toast } from '@/components/ui/use-toast'
 import { socket } from '@/lib/ws-client'
 import { router } from '@/router'
 
+import { NotificationsPopover } from '../../notifications/components/NotificationsPopover'
+
 import { getTasks, type GetTasksFilters } from '../api/getTasks'
 import { CardsView } from '../components/CardsView'
 import { KanbanView } from '../components/KanbanView'
@@ -99,6 +101,7 @@ export function TasksPage() {
   useEffect(() => {
     const handleTaskCreated = (_payload?: TaskEventPayload) => {
       void queryClient.invalidateQueries({ queryKey: ['tasks'] })
+      void queryClient.invalidateQueries({ queryKey: ['notifications'] })
     }
 
     const handleTaskUpdated = (payload: Task | TaskEventPayload) => {
@@ -127,6 +130,7 @@ export function TasksPage() {
       )
 
       queryClient.setQueryData<Task>(['task', updatedTask.id], updatedTask)
+      void queryClient.invalidateQueries({ queryKey: ['notifications'] })
     }
 
     const handleCommentNew = (comment: CommentDTO) => {
@@ -141,6 +145,8 @@ export function TasksPage() {
       void queryClient.invalidateQueries({
         queryKey: ['task', comment.taskId],
       })
+
+      void queryClient.invalidateQueries({ queryKey: ['notifications'] })
 
       toast({
         title: 'Novo comentário',
@@ -261,7 +267,10 @@ export function TasksPage() {
           onSearchTermChange={handleSearchTermChange}
         />
 
-        <ViewSwitcher className="md:self-end" />
+        <div className="flex items-center justify-end gap-2 md:self-end">
+          <NotificationsPopover />
+          <ViewSwitcher />
+        </div>
       </div>
 
       {errorMessage ? (


### PR DESCRIPTION
## Summary
- add a notifications API client and schema for parsing paginated results
- show a bell popover on the tasks page with real-time updates from stored notifications

## Testing
- pnpm --filter @apps/web test

------
https://chatgpt.com/codex/tasks/task_e_68e74544f744832ba477a80bc6d2631e