### PR TITLE
Limit task card text in board view

### DIFF
--- a/apps/web/src/features/tasks/components/KanbanView.tsx
+++ b/apps/web/src/features/tasks/components/KanbanView.tsx
@@ -67,7 +67,12 @@ export function KanbanView({
                 ))
               ) : columnTasks.length > 0 ? (
                 columnTasks.map((task) => (
-                  <TaskCard key={task.id} task={task} onSelect={onSelectTask} />
+                  <TaskCard
+                    key={task.id}
+                    task={task}
+                    onSelect={onSelectTask}
+                    truncateForBoard
+                  />
                 ))
               ) : (
                 <p className="rounded-lg border border-dashed border-border bg-background/40 p-6 text-center text-sm text-muted-foreground">

--- a/apps/web/src/features/tasks/components/TaskCard.tsx
+++ b/apps/web/src/features/tasks/components/TaskCard.tsx
@@ -26,6 +26,7 @@ interface TaskCardProps {
   task: Task
   className?: string
   onSelect?: (task: Task) => void
+  truncateForBoard?: boolean
 }
 
 function formatDueDate(dueDate?: string | null) {
@@ -53,7 +54,7 @@ function getBadgeClassName(priority: TaskPriority) {
   )
 }
 
-export function TaskCard({ task, className, onSelect }: TaskCardProps) {
+export function TaskCard({ task, className, onSelect, truncateForBoard = false }: TaskCardProps) {
   const isInteractive = Boolean(onSelect)
 
   const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
@@ -81,9 +82,23 @@ export function TaskCard({ task, className, onSelect }: TaskCardProps) {
     >
       <div className="flex items-start justify-between gap-4">
         <div className="space-y-2">
-          <h3 className="text-base font-semibold text-foreground">{task.title}</h3>
+          <h3
+            className={cn(
+              'text-base font-semibold text-foreground',
+              truncateForBoard && 'line-clamp-2',
+            )}
+          >
+            {task.title}
+          </h3>
           {task.description ? (
-            <p className="text-sm text-muted-foreground">{task.description}</p>
+            <p
+              className={cn(
+                'text-sm text-muted-foreground',
+                truncateForBoard && 'line-clamp-4',
+              )}
+            >
+              {task.description}
+            </p>
           ) : null}
         </div>
 


### PR DESCRIPTION
## Summary
- add an option to clamp the task card title and description text
- enable the line clamp in the kanban board view to limit title and description length

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e74646f798832b9d8e1b1ebc85edf8