### PR TITLE
feat: add shared users contract and gateway integration

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -9,6 +9,7 @@ import { AuthModule } from './auth/auth.module';
 import { TasksModule } from './tasks/tasks.module';
 import { LoggingModule } from './common/logging/logging.module';
 import { NotificationsModule } from './notifications/notifications.module';
+import { UsersModule } from './users/users.module';
 
 @Module({
   imports: [
@@ -40,6 +41,7 @@ import { NotificationsModule } from './notifications/notifications.module';
     AuthModule,
     TasksModule,
     NotificationsModule,
+    UsersModule,
     HealthModule,
     LoggingModule,
   ],

--- a/apps/api/src/auth/auth-gateway.service.ts
+++ b/apps/api/src/auth/auth-gateway.service.ts
@@ -1,20 +1,18 @@
-import {
-  HttpException,
-  HttpStatus,
-  Inject,
-  Injectable,
-} from '@nestjs/common';
+import { HttpException, HttpStatus, Inject, Injectable } from '@nestjs/common';
 import { ClientProxy, RpcException } from '@nestjs/microservices';
 import { lastValueFrom } from 'rxjs';
 import { AUTH_SERVICE } from './auth.constants';
 import { LoginDto, RegisterDto } from './dto';
 import {
   AUTH_MESSAGE_PATTERNS,
+  USERS_MESSAGE_PATTERNS,
   type AuthLoginResponse,
   type AuthLogoutResponse,
   type AuthRefreshResponse,
   type AuthRegisterResponse,
   type AuthRefreshRequest,
+  type UserDTO,
+  type UserListFilters,
 } from '@repo/types';
 
 @Injectable()
@@ -22,7 +20,7 @@ export class AuthGatewayService {
   constructor(
     @Inject(AUTH_SERVICE)
     private readonly authClient: ClientProxy,
-  ) { }
+  ) {}
 
   async register(dto: RegisterDto): Promise<AuthRegisterResponse> {
     try {
@@ -66,6 +64,26 @@ export class AuthGatewayService {
     }
   }
 
+  async findAllUsers(filters: UserListFilters = {}): Promise<UserDTO[]> {
+    try {
+      return await lastValueFrom(
+        this.authClient.send(USERS_MESSAGE_PATTERNS.FIND_ALL, filters),
+      );
+    } catch (error) {
+      throw this.toHttpException(error);
+    }
+  }
+
+  async findUserById(id: string): Promise<UserDTO> {
+    try {
+      return await lastValueFrom(
+        this.authClient.send(USERS_MESSAGE_PATTERNS.FIND_BY_ID, { id }),
+      );
+    } catch (error) {
+      throw this.toHttpException(error);
+    }
+  }
+
   async ping() {
     try {
       return await lastValueFrom(
@@ -89,7 +107,11 @@ export class AuthGatewayService {
     // Sometimes microservices return plain objects (not RpcException instances)
     // when proxied through the client. Handle those shapes here so status codes
     // like 401/409 from the auth service are preserved instead of becoming 500.
-    if (typeof error === 'object' && error !== null && !(error instanceof Error)) {
+    if (
+      typeof error === 'object' &&
+      error !== null &&
+      !(error instanceof Error)
+    ) {
       const obj = error as Record<string, unknown>;
 
       // If the object looks like an HTTP/RPC error (has message/status/statusCode/code),
@@ -101,8 +123,12 @@ export class AuthGatewayService {
         'error' in obj ||
         'code' in obj
       ) {
-        const body = this.normalizeBody({ ...(obj as Record<string, unknown>) });
-        const statusCode = this.extractStatusCode(body.statusCode ?? body.status);
+        const body = this.normalizeBody({
+          ...obj,
+        });
+        const statusCode = this.extractStatusCode(
+          body.statusCode ?? body.status,
+        );
         return new HttpException(body, statusCode, { cause: error });
       }
     }
@@ -135,10 +161,10 @@ export class AuthGatewayService {
 
   private normalizeRpcException(error: RpcException):
     | {
-      statusCode: number;
-      body: Record<string, unknown>;
-      cause?: unknown;
-    }
+        statusCode: number;
+        body: Record<string, unknown>;
+        cause?: unknown;
+      }
     | undefined {
     const rpcError = error.getError();
 
@@ -194,7 +220,9 @@ export class AuthGatewayService {
     return undefined;
   }
 
-  private normalizeBody(source: Record<string, unknown>): Record<string, unknown> {
+  private normalizeBody(
+    source: Record<string, unknown>,
+  ): Record<string, unknown> {
     const body: Record<string, unknown> = { ...source };
 
     const statusCode = this.extractStatusCode(body.statusCode ?? body.status);

--- a/apps/api/src/tasks/tasks.controller.ts
+++ b/apps/api/src/tasks/tasks.controller.ts
@@ -37,7 +37,10 @@ import type {
   ListTaskCommentsFilters,
 } from './tasks.service';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
-import { CurrentUser, type CurrentUserPayload } from '../auth/current-user.decorator';
+import {
+  CurrentUser,
+  type CurrentUserPayload,
+} from '../auth/current-user.decorator';
 
 @UseGuards(JwtAuthGuard)
 @ApiBearerAuth()
@@ -60,6 +63,7 @@ export class TasksController {
       status: query.status,
       priority: query.priority,
       search: query.search,
+      assigneeId: query.assigneeId,
       dueDate: query.dueDate,
     });
 
@@ -198,9 +202,12 @@ export class TasksController {
     return { data: item };
   }
 
-  private toPaginatedResponse<T>(
-    result: { data: T[]; total: number; page: number; limit: number },
-  ): PaginatedResponse<T> {
+  private toPaginatedResponse<T>(result: {
+    data: T[];
+    total: number;
+    page: number;
+    limit: number;
+  }): PaginatedResponse<T> {
     const totalPages =
       result.limit > 0 ? Math.ceil(result.total / result.limit) : 0;
 

--- a/apps/api/src/users/users.controller.ts
+++ b/apps/api/src/users/users.controller.ts
@@ -1,0 +1,45 @@
+import { Controller, Get, Param, Query, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiOkResponse, ApiTags } from '@nestjs/swagger';
+import {
+  ListUsersQueryDto,
+  type ApiResponse,
+  type UserDTO,
+  UserIdParamDto,
+  type UserListFilters,
+} from '@repo/types';
+
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { UsersService } from './users.service';
+
+@UseGuards(JwtAuthGuard)
+@ApiBearerAuth()
+@ApiTags('users')
+@Controller('users')
+export class UsersController {
+  constructor(private readonly usersService: UsersService) {}
+
+  @Get()
+  @ApiOkResponse({ description: 'List users' })
+  async findAll(
+    @Query() query: ListUsersQueryDto,
+  ): Promise<ApiResponse<UserDTO[]>> {
+    const filters: UserListFilters = {};
+    const search = query.search?.trim();
+
+    if (search) {
+      filters.search = search;
+    }
+
+    const users = await this.usersService.findAll(filters);
+    return { data: users };
+  }
+
+  @Get(':id')
+  @ApiOkResponse({ description: 'Retrieve a user by id' })
+  async findById(
+    @Param() params: UserIdParamDto,
+  ): Promise<ApiResponse<UserDTO>> {
+    const user = await this.usersService.findById(params.id);
+    return { data: user };
+  }
+}

--- a/apps/api/src/users/users.module.ts
+++ b/apps/api/src/users/users.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+
+import { AuthModule } from '../auth/auth.module';
+import { UsersController } from './users.controller';
+import { UsersService } from './users.service';
+
+@Module({
+  imports: [AuthModule],
+  controllers: [UsersController],
+  providers: [UsersService],
+})
+export class UsersModule {}

--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@nestjs/common';
+import type { UserDTO, UserListFilters } from '@repo/types';
+
+import { AuthGatewayService } from '../auth/auth-gateway.service';
+
+@Injectable()
+export class UsersService {
+  constructor(private readonly authGateway: AuthGatewayService) {}
+
+  findAll(filters: UserListFilters = {}): Promise<UserDTO[]> {
+    return this.authGateway.findAllUsers(filters);
+  }
+
+  findById(id: string): Promise<UserDTO> {
+    return this.authGateway.findUserById(id);
+  }
+}

--- a/apps/auth/src/users/users.controller.ts
+++ b/apps/auth/src/users/users.controller.ts
@@ -1,35 +1,100 @@
-import { Controller } from '@nestjs/common';
+import { BadRequestException, Controller } from '@nestjs/common';
 import { MessagePattern, Payload } from '@nestjs/microservices';
 import { UsersService } from './users.service';
 import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
+import {
+  USERS_MESSAGE_PATTERNS,
+  type UserListFilters,
+  type UsersFindAllPayload,
+  type UsersFindByIdPayload,
+} from '@repo/types';
 
 @Controller('users')
 export class UsersController {
   constructor(private readonly usersService: UsersService) { }
 
-  @MessagePattern('createUser')
+  @MessagePattern(USERS_MESSAGE_PATTERNS.CREATE)
   create(@Payload() createUserDto: CreateUserDto) {
     return this.usersService.create(createUserDto);
   }
 
-  @MessagePattern('findAllUsers')
-  findAll() {
-    return this.usersService.findAll();
+  @MessagePattern(USERS_MESSAGE_PATTERNS.FIND_ALL)
+  findAll(@Payload() payload: UsersFindAllPayload | undefined) {
+    const filters = this.extractFilters(payload);
+    return this.usersService.findAll(filters);
   }
 
-  @MessagePattern('findOneUser')
-  findOne(@Payload() id: string) {
-    return this.usersService.findOneById(id);
+  @MessagePattern(USERS_MESSAGE_PATTERNS.FIND_BY_ID)
+  findOne(@Payload() payload: UsersFindByIdPayload | string | undefined) {
+    const id = this.extractId(payload);
+    return this.usersService.findById(id);
   }
 
-  @MessagePattern('updateUser')
-  update(@Payload() data: { id: string, UpdateUserDto: UpdateUserDto }) {
-    return this.usersService.update(data.id, data.UpdateUserDto);
+  @MessagePattern(USERS_MESSAGE_PATTERNS.UPDATE)
+  update(
+    @Payload()
+    payload:
+      | { id?: string; data?: UpdateUserDto; UpdateUserDto?: UpdateUserDto }
+      | undefined,
+  ) {
+    if (!payload || typeof payload !== 'object') {
+      throw new BadRequestException('Update payload is required');
+    }
+
+    const id = this.extractId(payload);
+    const data = payload.data ?? payload.UpdateUserDto;
+
+    if (!data) {
+      throw new BadRequestException('Update data is required');
+    }
+
+    return this.usersService.update(id, data);
   }
 
-  @MessagePattern('removeUser')
-  remove(@Payload() id: string) {
+  @MessagePattern(USERS_MESSAGE_PATTERNS.REMOVE)
+  remove(@Payload() payload: UsersFindByIdPayload | string | undefined) {
+    const id = this.extractId(payload);
     return this.usersService.remove(id);
+  }
+
+  private extractFilters(
+    payload: UsersFindAllPayload | undefined,
+  ): UserListFilters {
+    if (!payload || typeof payload !== 'object') {
+      return {};
+    }
+
+    const search =
+      typeof payload.search === 'string' ? payload.search.trim() : undefined;
+
+    return search && search.length > 0 ? { search } : {};
+  }
+
+  private extractId(
+    payload:
+      | UsersFindByIdPayload
+      | { id?: string }
+      | string
+      | undefined,
+  ): string {
+    if (typeof payload === 'string') {
+      const trimmed = payload.trim();
+      if (trimmed.length > 0) {
+        return trimmed;
+      }
+    }
+
+    if (payload && typeof payload === 'object') {
+      const id = (payload as { id?: unknown }).id;
+      if (typeof id === 'string') {
+        const trimmed = id.trim();
+        if (trimmed.length > 0) {
+          return trimmed;
+        }
+      }
+    }
+
+    throw new BadRequestException('User id is required');
   }
 }

--- a/packages/types/src/contracts/common/dtos/user.ts
+++ b/packages/types/src/contracts/common/dtos/user.ts
@@ -1,1 +1,9 @@
-export { type User, type UserDTO } from "../../../dto/user.js";
+export {
+  type User,
+  type UserDTO,
+  type UserListFilters,
+  type UserListFiltersDTO,
+  ListUsersDto,
+  ListUsersQueryDto,
+  UserIdParamDto,
+} from "../../../dto/user.js";

--- a/packages/types/src/contracts/rpc/index.ts
+++ b/packages/types/src/contracts/rpc/index.ts
@@ -1,3 +1,4 @@
 export * from "./auth.js";
 export * from "./tasks.js";
 export * from "./notifications.js";
+export * from "./users.js";

--- a/packages/types/src/contracts/rpc/users.ts
+++ b/packages/types/src/contracts/rpc/users.ts
@@ -1,0 +1,34 @@
+import type {
+  UserDTO,
+  UserListFiltersDTO,
+} from "../../dto/user.js";
+import type { CorrelatedMessage } from "../common/correlation.js";
+
+export const USERS_MESSAGE_PATTERNS = {
+  CREATE: "users.create",
+  FIND_ALL: "users.findAll",
+  FIND_BY_ID: "users.findById",
+  UPDATE: "users.update",
+  REMOVE: "users.remove",
+} as const;
+
+export type UsersMessagePatterns = typeof USERS_MESSAGE_PATTERNS;
+export type UsersMessagePattern =
+  UsersMessagePatterns[keyof UsersMessagePatterns];
+
+export type UsersFindAllPayload = CorrelatedMessage<UserListFiltersDTO>;
+export type UsersFindAllResult = UserDTO[];
+
+export type UsersFindByIdPayload = CorrelatedMessage<{ id: string }>;
+export type UsersFindByIdResult = UserDTO;
+
+export interface UsersRpcContractMap {
+  [USERS_MESSAGE_PATTERNS.FIND_ALL]: {
+    payload: UsersFindAllPayload;
+    response: UsersFindAllResult;
+  };
+  [USERS_MESSAGE_PATTERNS.FIND_BY_ID]: {
+    payload: UsersFindByIdPayload;
+    response: UsersFindByIdResult;
+  };
+}

--- a/packages/types/src/dto/index.ts
+++ b/packages/types/src/dto/index.ts
@@ -4,5 +4,5 @@ export * from "./task-audit-log.js";
 export * from "./comment.js";
 export * from "./notification.js";
 export type * from "./tokens.js";
-export type * from "./user.js";
+export * from "./user.js";
 export type * from "./http.js";

--- a/packages/types/src/dto/task.ts
+++ b/packages/types/src/dto/task.ts
@@ -21,6 +21,8 @@ import { CorrelatedDto } from "./correlation.js";
 export interface TaskAssigneeDTO {
   id: string;
   username: string;
+  name?: string | null;
+  email?: string | null;
 }
 
 export type TaskAssignee = TaskAssigneeDTO;
@@ -118,6 +120,16 @@ export class TaskAssigneeDto implements TaskAssigneeDTO {
   @IsString()
   @IsNotEmpty()
   username!: string;
+
+  @IsOptional()
+  @ValidateIf((_, value) => value !== null)
+  @IsString()
+  name?: string | null;
+
+  @IsOptional()
+  @ValidateIf((_, value) => value !== null)
+  @IsEmail()
+  email?: string | null;
 }
 
 export class CreateTaskDto implements CreateTaskDTO {
@@ -298,6 +310,10 @@ export class ListTasksQueryDto {
   @IsOptional()
   @IsString()
   search?: string;
+
+  @IsOptional()
+  @IsUUID()
+  assigneeId?: string;
 
   @IsOptional()
   @IsDateString()

--- a/packages/types/src/dto/user.ts
+++ b/packages/types/src/dto/user.ts
@@ -1,3 +1,7 @@
+import { IsOptional, IsString, IsUUID, IsNotEmpty } from "class-validator";
+
+import { CorrelatedDto } from "./correlation.js";
+
 export interface UserDTO {
   id: string;
   email: string;
@@ -5,3 +9,30 @@ export interface UserDTO {
 }
 
 export type User = UserDTO;
+
+export interface UserListFiltersDTO {
+  search?: string;
+}
+
+export type UserListFilters = UserListFiltersDTO;
+
+export class ListUsersDto
+  extends CorrelatedDto
+  implements UserListFiltersDTO
+{
+  @IsOptional()
+  @IsString()
+  search?: string;
+}
+
+export class ListUsersQueryDto implements UserListFiltersDTO {
+  @IsOptional()
+  @IsString()
+  search?: string;
+}
+
+export class UserIdParamDto {
+  @IsUUID()
+  @IsNotEmpty()
+  id!: string;
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -6,6 +6,7 @@ export * from "./enums/auth.js";
 
 // Tasks
 export * from "./contracts/rpc/tasks.js";
+export * from "./contracts/rpc/users.js";
 export {
   TASK_EVENT_PATTERNS,
   TASK_FORWARDING_PATTERNS,


### PR DESCRIPTION
## Summary
- expand task DTOs to support optional assignee identity fields and expose the assigneeId filter in HTTP queries
- add a shared users RPC contract, sanitize auth service responses, and centralize message pattern usage
- wire the API gateway to the new RPC endpoints with a protected users module so only id, email, and name reach the frontend

## Testing
- pnpm --filter @repo/types lint *(fails: existing warnings in legacy build scripts)*
- pnpm --filter @apps/api-gateway lint *(fails: pre-existing strict lint violations in untouched files)*

------
https://chatgpt.com/codex/tasks/task_e_68e748d49c9c832ba7e700ad87588b96