### PR TITLE
Normalize task assignee storage and event recipients

### DIFF
--- a/apps/tasks/package.json
+++ b/apps/tasks/package.json
@@ -90,6 +90,7 @@
     ],
     "moduleNameMapper": {
       "^(\\.{1,2}/.*)\\.js$": "$1",
+      "^@repo/logger$": "<rootDir>/../../../packages/logger/src/index.ts",
       "^@repo/types$": "<rootDir>/../../../packages/types/dist-cjs/index.js",
       "^@repo/types/(.*)$": "<rootDir>/../../../packages/types/dist-cjs/$1.js"
     }

--- a/apps/tasks/src/tasks/task-diff.util.spec.ts
+++ b/apps/tasks/src/tasks/task-diff.util.spec.ts
@@ -15,8 +15,17 @@ function createTask(overrides: Partial<Task> = {}): Task {
   task.priority = TaskPriority.MEDIUM;
   task.dueDate = new Date('2024-05-20T12:00:00.000Z');
   task.assignees = [
-    { id: 'b', username: 'beta' },
-    { id: 'a', username: 'alpha' },
+    {
+      id: 'b',
+      username: 'beta',
+      name: 'Beta Explorer',
+      email: 'beta@example.com',
+    },
+    {
+      id: 'a',
+      username: 'alpha',
+      name: null,
+    },
   ];
 
   Object.assign(task, overrides);
@@ -36,8 +45,17 @@ describe('task-diff.util', () => {
       priority: TaskPriority.MEDIUM,
       dueDate: new Date('2024-05-20T12:00:00.000Z'),
       assignees: [
-        { id: 'b', username: 'beta' },
-        { id: 'a', username: 'alpha' },
+        {
+          id: 'b',
+          username: 'beta',
+          name: 'Beta Explorer',
+          email: 'beta@example.com',
+        },
+        {
+          id: 'a',
+          username: 'alpha',
+          name: null,
+        },
       ],
     });
 
@@ -79,8 +97,8 @@ describe('task-diff.util', () => {
 
   it('ignores identical states and sorts assignees deterministically', () => {
     const assignees: TaskAssigneeDTO[] = [
-      { id: 'b', username: 'beta' },
-      { id: 'a', username: 'alpha' },
+      { id: 'b', username: 'beta', name: 'Beta Explorer' },
+      { id: 'a', username: 'alpha', name: null },
     ];
 
     const previous: TaskState = {

--- a/apps/tasks/src/tasks/task-diff.util.ts
+++ b/apps/tasks/src/tasks/task-diff.util.ts
@@ -87,10 +87,8 @@ function normalizeFieldValue(
       }
 
       return value
-        .map((assignee) => ({
-          id: assignee.id,
-          username: assignee.username,
-        }))
+        .filter((assignee) => assignee && typeof assignee.id === 'string')
+        .map(normalizeAssigneeForDiff)
         .sort((a, b) => a.id.localeCompare(b.id));
     case 'status':
     case 'priority':
@@ -100,4 +98,38 @@ function normalizeFieldValue(
     default:
       return typeof value === 'string' ? value : String(value);
   }
+}
+
+function normalizeAssigneeForDiff(assignee: TaskAssigneeDTO): TaskAssigneeDTO {
+  const normalized: TaskAssigneeDTO = {
+    id: typeof assignee.id === 'string' ? assignee.id.trim() : assignee.id,
+    username:
+      typeof assignee.username === 'string'
+        ? assignee.username.trim()
+        : assignee.username,
+  };
+
+  if (assignee.name === null) {
+    normalized.name = null;
+  } else if (typeof assignee.name === 'string') {
+    const trimmedName = assignee.name.trim();
+    if (trimmedName.length > 0) {
+      normalized.name = trimmedName;
+    } else {
+      normalized.name = null;
+    }
+  }
+
+  if (assignee.email === null) {
+    normalized.email = null;
+  } else if (typeof assignee.email === 'string') {
+    const trimmedEmail = assignee.email.trim();
+    if (trimmedEmail.length > 0) {
+      normalized.email = trimmedEmail;
+    } else {
+      normalized.email = null;
+    }
+  }
+
+  return normalized;
 }


### PR DESCRIPTION
## Summary
- normalize task assignees on create/update, trim assignee filters, and include recipients when emitting task events
- ensure audit diffs for assignee changes remain deterministic by normalizing comparison data
- expand unit coverage and Jest configuration for logger mocking and comment recipients

## Testing
- pnpm --filter @apps/tasks-service test

------
https://chatgpt.com/codex/tasks/task_e_68e75164dde8832bb10d12cf165a0ad3