### PR TITLE
Add coverage for assignee handling across services and UI

### DIFF
--- a/apps/api/src/tasks/tasks.events.controller.spec.ts
+++ b/apps/api/src/tasks/tasks.events.controller.spec.ts
@@ -1,0 +1,103 @@
+import type { RmqContext } from '@nestjs/microservices';
+import { AppLoggerService, runWithRequestContext } from '@repo/logger';
+
+import { TasksEventsController } from './tasks.events.controller';
+import type { TasksGateway } from './tasks.gateway';
+
+jest.mock('@repo/logger', () => {
+  const runWithRequestContext = jest.fn((_: unknown, handler: () => unknown) => handler());
+
+  class MockAppLoggerService {
+    withContext = jest.fn(() => this);
+    debug = jest.fn();
+    warn = jest.fn();
+    error = jest.fn();
+  }
+
+  return {
+    runWithRequestContext,
+    AppLoggerService: MockAppLoggerService,
+  };
+});
+
+describe('TasksEventsController', () => {
+  let emitMock: jest.Mock;
+  let ackMock: jest.Mock;
+  let controller: TasksEventsController;
+  let logger: AppLoggerService;
+
+  const createContext = (headers: Record<string, unknown> = {}): RmqContext => {
+    const message = {
+      content: Buffer.from('event'),
+      properties: { headers },
+    } as unknown;
+
+    return {
+      getChannelRef: () => ({ ack: ackMock }),
+      getMessage: () => message,
+    } as unknown as RmqContext;
+  };
+
+  beforeEach(() => {
+    emitMock = jest.fn();
+    ackMock = jest.fn();
+    logger = new AppLoggerService();
+    controller = new TasksEventsController(
+      { emitToClients: emitMock } as unknown as TasksGateway,
+      logger,
+    );
+
+    (runWithRequestContext as jest.Mock).mockClear();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('forwards task.created events with recipients and acknowledges the message', () => {
+    const payload = {
+      requestId: 'req-created',
+      task: { id: 'task-1', assignees: [] },
+      recipients: ['user-1', 'user-2'],
+    };
+
+    const context = createContext();
+
+    controller.onTaskCreated(payload, context);
+
+    expect(runWithRequestContext).toHaveBeenCalledTimes(1);
+    expect(runWithRequestContext).toHaveBeenCalledWith(
+      { requestId: 'req-created' },
+      expect.any(Function),
+    );
+    expect(emitMock).toHaveBeenCalledTimes(1);
+    expect(emitMock).toHaveBeenCalledWith('task:created', payload);
+    expect(ackMock).toHaveBeenCalledTimes(1);
+    expect(ackMock).toHaveBeenCalledWith(
+      expect.objectContaining({ content: expect.any(Buffer) }),
+    );
+  });
+
+  it('uses the request id from headers when forwarding update events without payload metadata', () => {
+    const payload = {
+      task: { id: 'task-2', assignees: [{ id: 'assignee-1' }] },
+      recipients: ['assignee-1'],
+    };
+
+    const context = createContext({ 'x-request-id': 'header-req' });
+
+    controller.onTaskUpdated(payload, context);
+
+    expect(runWithRequestContext).toHaveBeenCalledTimes(1);
+    expect(runWithRequestContext).toHaveBeenCalledWith(
+      { requestId: 'header-req' },
+      expect.any(Function),
+    );
+    expect(emitMock).toHaveBeenCalledTimes(1);
+    expect(emitMock).toHaveBeenCalledWith('task:updated', payload);
+    expect(ackMock).toHaveBeenCalledTimes(1);
+    expect(ackMock).toHaveBeenCalledWith(
+      expect.objectContaining({ content: expect.any(Buffer) }),
+    );
+  });
+});

--- a/apps/api/src/users/users.controller.spec.ts
+++ b/apps/api/src/users/users.controller.spec.ts
@@ -1,0 +1,57 @@
+jest.mock('@repo/logger', () => ({
+  getCurrentRequestContext: jest.fn(() => undefined),
+}));
+
+import { UsersController } from './users.controller';
+
+describe('UsersController', () => {
+  const createServiceMock = () => ({
+    findAll: jest.fn(),
+    findById: jest.fn(),
+  });
+
+  it('delega busca de usuários ao serviço normalizando filtros de pesquisa', async () => {
+    const service = createServiceMock();
+    const controller = new UsersController(service as any);
+    const expected = [
+      { id: 'user-1', name: 'Explorer 1', email: 'explorer1@example.com' },
+    ];
+    service.findAll.mockResolvedValue(expected);
+
+    const response = await controller.findAll({
+      search: '  explorer  ',
+      page: 2,
+      limit: 5,
+    } as any);
+
+    expect(service.findAll).toHaveBeenCalledWith({
+      search: 'explorer',
+      page: 2,
+      limit: 5,
+    });
+    expect(response).toEqual({ data: expected });
+  });
+
+  it('mantém filtros vazios quando a busca está ausente', async () => {
+    const service = createServiceMock();
+    const controller = new UsersController(service as any);
+    service.findAll.mockResolvedValue([]);
+
+    const response = await controller.findAll({} as any);
+
+    expect(service.findAll).toHaveBeenCalledWith({});
+    expect(response).toEqual({ data: [] });
+  });
+
+  it('busca usuário por id através do serviço', async () => {
+    const service = createServiceMock();
+    const controller = new UsersController(service as any);
+    const user = { id: 'user-42', name: 'Explorer 42', email: 'e42@example.com' };
+    service.findById.mockResolvedValue(user);
+
+    const response = await controller.findById({ id: 'user-42' } as any);
+
+    expect(service.findById).toHaveBeenCalledWith('user-42');
+    expect(response).toEqual({ data: user });
+  });
+});

--- a/apps/web/src/features/tasks/components/__tests__/AssigneeMultiSelect.test.tsx
+++ b/apps/web/src/features/tasks/components/__tests__/AssigneeMultiSelect.test.tsx
@@ -1,0 +1,234 @@
+import { useState, type ReactElement } from 'react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { TaskAssignee } from '@repo/types'
+import { Controller, useForm } from 'react-hook-form'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { AssigneeMultiSelect } from '../AssigneeMultiSelect'
+import { getUsers } from '@/features/users/api/getUsers'
+
+vi.mock('@/features/users/api/getUsers', () => ({
+  getUsers: vi.fn(),
+}))
+
+const getUsersMock = getUsers as unknown as vi.MockedFunction<typeof getUsers>
+
+const createdClients: QueryClient[] = []
+
+function renderWithClient(children: ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  })
+
+  createdClients.push(queryClient)
+
+  return render(
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>,
+  )
+}
+
+function selectOption(option: HTMLElement) {
+  fireEvent.pointerDown(option, { pointerId: 1 })
+  fireEvent.pointerUp(option, { pointerId: 1 })
+  fireEvent.click(option)
+}
+
+function openSelector(): HTMLElement {
+  const triggers = screen.getAllByRole('combobox')
+  const trigger = triggers[triggers.length - 1]
+  fireEvent.pointerDown(trigger, { pointerId: 1 })
+  fireEvent.pointerUp(trigger, { pointerId: 1 })
+  fireEvent.click(trigger)
+  return trigger
+}
+
+async function findOption(text: string): Promise<HTMLElement> {
+  const candidates = await screen.findAllByText(text)
+  const option = candidates.find((element) => !element.closest('li'))
+
+  if (!option) {
+    throw new Error(`Option "${text}" not found`)
+  }
+
+  return option as HTMLElement
+}
+
+afterEach(() => {
+  createdClients.forEach((client) => client.clear())
+  createdClients.length = 0
+  vi.clearAllMocks()
+})
+
+describe('AssigneeMultiSelect', () => {
+  beforeAll(() => {
+    class ResizeObserverMock {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+
+    Object.defineProperty(globalThis, 'ResizeObserver', {
+      writable: true,
+      configurable: true,
+      value: ResizeObserverMock,
+    })
+  })
+
+  beforeEach(() => {
+    getUsersMock.mockResolvedValue([
+      { id: 'user-1', name: 'Explorer 1', email: 'user1@example.com' },
+      { id: 'user-2', name: 'Explorer 2', email: 'user2@example.com' },
+    ])
+  })
+
+  it('carrega usuários conforme a busca e exibe os resultados', async () => {
+    renderWithClient(
+      <AssigneeMultiSelect value={[]} onChange={() => {}} />,
+    )
+
+    openSelector()
+
+    await waitFor(() => {
+      expect(getUsersMock).toHaveBeenCalledWith({ search: '', limit: 20 })
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('Explorer 1')).toBeTruthy()
+      expect(screen.getByText('Explorer 2')).toBeTruthy()
+    })
+
+    const searchInput = screen.getByPlaceholderText('Buscar responsável...')
+    fireEvent.change(searchInput, { target: { value: 'Explorer' } })
+
+    await waitFor(() => {
+      expect(getUsersMock).toHaveBeenLastCalledWith({
+        search: 'Explorer',
+        limit: 20,
+      })
+    })
+  })
+
+  it('permite selecionar e remover múltiplos responsáveis', async () => {
+    function Wrapper() {
+      const [value, setValue] = useState<TaskAssignee[]>([])
+      return <AssigneeMultiSelect value={value} onChange={setValue} />
+    }
+
+    renderWithClient(<Wrapper />)
+
+    openSelector()
+
+    await waitFor(() => {
+      expect(getUsersMock).toHaveBeenCalled()
+    })
+
+    const optionExplorer1 = await findOption('Explorer 1')
+    const optionExplorer2 = await findOption('Explorer 2')
+
+    selectOption(optionExplorer1 as HTMLElement)
+
+    const removeFirst = await screen.findByRole('button', {
+      name: /remover responsável explorer 1/i,
+    })
+
+    selectOption(optionExplorer2 as HTMLElement)
+
+    await screen.findByRole('button', {
+      name: /remover responsável explorer 2/i,
+    })
+
+    fireEvent.click(removeFirst)
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole('button', {
+          name: /remover responsável explorer 1/i,
+        }),
+      ).toBeNull()
+      expect(
+        screen.getByRole('button', {
+          name: /remover responsável explorer 2/i,
+        }),
+      ).toBeTruthy()
+    })
+  })
+
+  it('integra com formulários controlados utilizando react-hook-form', async () => {
+    const handleSubmit = vi.fn()
+
+    function FormWrapper() {
+      const { control, handleSubmit: onSubmit } = useForm<{ assignees: TaskAssignee[] }>({
+        defaultValues: { assignees: [] },
+      })
+
+      return (
+        <form onSubmit={onSubmit(handleSubmit)}>
+          <Controller
+            control={control}
+            name="assignees"
+            render={({ field }) => (
+              <AssigneeMultiSelect
+                value={field.value}
+                onChange={field.onChange}
+              />
+            )}
+          />
+          <button type="submit">Salvar</button>
+        </form>
+      )
+    }
+
+    renderWithClient(<FormWrapper />)
+
+    openSelector()
+
+    await waitFor(() => {
+      expect(getUsersMock).toHaveBeenCalled()
+    })
+
+    const optionExplorer1 = await findOption('Explorer 1')
+    const optionExplorer2 = await findOption('Explorer 2')
+
+    selectOption(optionExplorer1)
+    const removeExplorer1 = await screen.findAllByRole('button', {
+      name: /remover responsável explorer 1/i,
+    })
+
+    selectOption(optionExplorer2)
+    const removeExplorer2 = await screen.findAllByRole('button', {
+      name: /remover responsável explorer 2/i,
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /salvar/i }))
+
+    await waitFor(() => {
+      expect(handleSubmit).toHaveBeenCalledTimes(1)
+    })
+
+    const submitted = handleSubmit.mock.calls[0][0]
+
+    expect(submitted.assignees).toEqual([
+      {
+        id: 'user-1',
+        username: 'Explorer 1',
+        name: 'Explorer 1',
+        email: 'user1@example.com',
+      },
+      {
+        id: 'user-2',
+        username: 'Explorer 2',
+        name: 'Explorer 2',
+        email: 'user2@example.com',
+      },
+    ])
+
+    // Clean up selection to avoid interference with other tests
+    fireEvent.click(removeExplorer1[removeExplorer1.length - 1])
+    fireEvent.click(removeExplorer2[removeExplorer2.length - 1])
+  })
+})

--- a/packages/types/dist/contracts/rpc/users.d.ts
+++ b/packages/types/dist/contracts/rpc/users.d.ts
@@ -1,17 +1,19 @@
 import type { UserDTO, UserListFiltersDTO } from "../../dto/user.js";
 import type { CorrelatedMessage } from "../common/correlation.js";
 export declare const USERS_MESSAGE_PATTERNS: {
-    CREATE: "users.create";
-    FIND_ALL: "users.findAll";
-    FIND_BY_ID: "users.findById";
-    UPDATE: "users.update";
-    REMOVE: "users.remove";
+    readonly CREATE: "users.create";
+    readonly FIND_ALL: "users.findAll";
+    readonly FIND_BY_ID: "users.findById";
+    readonly UPDATE: "users.update";
+    readonly REMOVE: "users.remove";
 };
 export type UsersMessagePatterns = typeof USERS_MESSAGE_PATTERNS;
 export type UsersMessagePattern = UsersMessagePatterns[keyof UsersMessagePatterns];
 export type UsersFindAllPayload = CorrelatedMessage<UserListFiltersDTO>;
 export type UsersFindAllResult = UserDTO[];
-export type UsersFindByIdPayload = CorrelatedMessage<{ id: string }>;
+export type UsersFindByIdPayload = CorrelatedMessage<{
+    id: string;
+}>;
 export type UsersFindByIdResult = UserDTO;
 export interface UsersRpcContractMap {
     [USERS_MESSAGE_PATTERNS.FIND_ALL]: {
@@ -23,3 +25,4 @@ export interface UsersRpcContractMap {
         response: UsersFindByIdResult;
     };
 }
+//# sourceMappingURL=users.d.ts.map

--- a/packages/types/dist/contracts/rpc/users.js
+++ b/packages/types/dist/contracts/rpc/users.js
@@ -1,7 +1,7 @@
 export const USERS_MESSAGE_PATTERNS = {
-  CREATE: "users.create",
-  FIND_ALL: "users.findAll",
-  FIND_BY_ID: "users.findById",
-  UPDATE: "users.update",
-  REMOVE: "users.remove",
+    CREATE: "users.create",
+    FIND_ALL: "users.findAll",
+    FIND_BY_ID: "users.findById",
+    UPDATE: "users.update",
+    REMOVE: "users.remove",
 };


### PR DESCRIPTION
## Summary
- extend the tasks service unit suite to validate audit logs and event recipients when creating or updating tasks with responsáveis 【F:apps/tasks/src/tasks/tasks.service.spec.ts†L224-L565】
- add API gateway specs to ensure task events propagate with correlation metadata and that the `/users` controller trims and delegates filters correctly 【F:apps/api/src/tasks/tasks.events.controller.spec.ts†L1-L102】【F:apps/api/src/users/users.controller.spec.ts†L1-L56】
- exercise the AssigneeMultiSelect component for searching, multi-selection and react-hook-form integration, plus refresh the compiled users RPC contract outputs 【F:apps/web/src/features/tasks/components/__tests__/AssigneeMultiSelect.test.tsx†L1-L233】【F:packages/types/dist/contracts/rpc/users.d.ts†L1-L28】

## Testing
- pnpm --filter @apps/tasks-service test -- tasks.service.spec.ts 【a1e0d0†L1-L13】
- pnpm --filter @apps/api-gateway test -- tasks.events.controller.spec.ts 【198a00†L1-L10】
- pnpm --filter @apps/api-gateway test -- users.controller.spec.ts 【aea2ab†L1-L8】
- pnpm --filter @apps/web test -- AssigneeMultiSelect.test.tsx 【389bbe†L1-L14】

------
https://chatgpt.com/codex/tasks/task_e_68e75c5270bc832baf69b13af3c95f82