### PR TITLE
Emit tasks updated forwarding event

### DIFF
--- a/apps/tasks/src/tasks/tasks.service.ts
+++ b/apps/tasks/src/tasks/tasks.service.ts
@@ -7,6 +7,7 @@ import { Task } from './task.entity';
 import { TASKS_EVENTS_CLIENT } from './tasks.constants';
 import {
   TASK_EVENT_PATTERNS,
+  TASK_FORWARDING_PATTERNS,
   type TaskActor,
   type TaskAuditLogActorDTO,
   type TaskAuditLogChangeDTO,
@@ -203,15 +204,15 @@ export class TasksService {
       changes: normalizedChanges,
     });
 
-    await this.emitEvent(
-      TASK_EVENT_PATTERNS.UPDATED,
-      this.createEventPayload(
-        saved,
-        auditActor,
-        normalizedChanges,
-        this.getAssigneeRecipients(saved.assignees),
-      ),
+    const payload = this.createEventPayload(
+      saved,
+      auditActor,
+      normalizedChanges,
+      this.getAssigneeRecipients(saved.assignees),
     );
+
+    await this.emitEvent(TASK_EVENT_PATTERNS.UPDATED, payload);
+    await this.emitEvent(TASK_FORWARDING_PATTERNS.UPDATED, payload);
 
     return saved;
   }


### PR DESCRIPTION
## Summary
- emit the `tasks.updated` forwarding message after sending the core update event so downstream services keep receiving the payload
- expand the tasks service unit tests to assert the forwarded event, including recipient propagation and request id correlation

## Testing
- pnpm --filter @repo/types build
- pnpm --filter @apps/tasks-service test
- pnpm --filter @apps/notifications-service test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68e76cda76dc832b8fada8f6617e9a8a