### PR TITLE
docs: criar README final e diagramas do desafio

### DIFF
--- a/docs/architecture.mmd
+++ b/docs/architecture.mmd
@@ -1,0 +1,31 @@
+%% Arquitetura de containers Jungle Gaming
+```mermaid
+flowchart LR
+    subgraph Client
+        web[Web App\nReact + TanStack Router]
+    end
+
+    subgraph Edge[Gateway]
+        apiGateway[API Gateway\nNestJS HTTP + WS]
+    end
+
+    subgraph Services[Microservices]
+        authService[Auth Service\nNestJS]
+        tasksService[Tasks Service\nNestJS]
+        notificationsService[Notifications Service\nNestJS]
+    end
+
+    subgraph Infra[Infraestrutura Compartilhada]
+        rabbitmq[(RabbitMQ)]
+        postgres[(PostgreSQL)]
+    end
+
+    web -->|HTTPS / WebSocket| apiGateway
+    apiGateway -->|HTTP / RPC| authService
+    apiGateway -->|HTTP / RPC| tasksService
+    apiGateway -->|WebSocket| notificationsService
+
+    tasksService <--> rabbitmq
+    notificationsService <--> rabbitmq
+    authService --> postgres
+    tasksService --> postgres

--- a/docs/flows/comment-realtime.mmd
+++ b/docs/flows/comment-realtime.mmd
@@ -1,0 +1,23 @@
+%% Fluxo de comentário com atualização em tempo real
+```mermaid
+sequenceDiagram
+    autonumber
+    participant U as Usuário
+    participant Web as Web App
+    participant API as API Gateway
+    participant Tasks as Tasks Service
+    participant MQ as RabbitMQ
+    participant Notif as Notifications Service
+    participant WS as WebSocket Clients
+
+    U->>Web: Digita comentário
+    Web->>API: POST /tasks/:id/comments
+    API->>Tasks: RPC addComment
+    Tasks-->>API: Confirma comentário
+    Tasks->>MQ: Publish comment.new
+    API-->>Web: 201 Created + comentário
+    MQ-->>Notif: comment.new
+    Notif->>WS: Emit WS "task.comment"
+    WS-->>U: Atualiza thread em tempo real
+    WS-->>Outros: Badge "Novo comentário"
+```

--- a/docs/flows/create-task.mmd
+++ b/docs/flows/create-task.mmd
@@ -1,0 +1,22 @@
+%% Fluxo de criação de tarefa e notificação
+```mermaid
+sequenceDiagram
+    autonumber
+    participant U as Usuário
+    participant Web as Web App
+    participant API as API Gateway
+    participant Tasks as Tasks Service
+    participant MQ as RabbitMQ
+    participant Notif as Notifications Service
+    participant WS as WebSocket Clients
+
+    U->>Web: Formulário "Nova tarefa"
+    Web->>API: POST /tasks
+    API->>Tasks: RPC createTask
+    Tasks-->>API: Tarefa criada
+    Tasks->>MQ: Publish task.created
+    API-->>Web: 201 Created + payload
+    MQ-->>Notif: task.created
+    Notif->>WS: Broadcast evento realtime
+    WS-->>U: Toast/Atualização da lista
+```

--- a/docs/flows/login-refresh.mmd
+++ b/docs/flows/login-refresh.mmd
@@ -1,0 +1,22 @@
+%% Fluxo de Login e Refresh Token
+```mermaid
+sequenceDiagram
+    autonumber
+    participant U as Usuário
+    participant Web as Web App
+    participant API as API Gateway
+    participant Auth as Auth Service
+    U->>Web: Envia credenciais (email, senha)
+    Web->>API: POST /auth/login
+    API->>Auth: RPC validateUser + issueTokens
+    Auth-->>API: accessToken + refreshToken (HTTP-only)
+    API-->>Web: 200 OK + tokens
+    Web-->>U: Sessão iniciada
+    Note over Web: Armazena accessToken em memória segura
+    Note over U,Web: Tempo passa...
+    Web->>API: POST /auth/refresh (cookie)
+    API->>Auth: validateRefreshToken
+    Auth-->>API: Novo par de tokens
+    API-->>Web: 200 OK + novos tokens
+    Web-->>U: Sessão mantida
+```


### PR DESCRIPTION
## Resumo
- reescreve o README principal com visão executiva do desafio, instruções de execução e diferenciais
- adiciona diagramas Mermaid de arquitetura e fluxos principais em /docs

## Testes
- não foram necessários testes automatizados

------
https://chatgpt.com/codex/tasks/task_e_68e776aa5ea8832b8926576d4961317b