### PR TITLE
fix: preserve http status in rpc exceptions

### DIFF
--- a/apps/notifications/src/common/rpc.utils.spec.ts
+++ b/apps/notifications/src/common/rpc.utils.spec.ts
@@ -1,0 +1,44 @@
+import { BadRequestException, HttpException, HttpStatus } from '@nestjs/common';
+import { RpcException } from '@nestjs/microservices';
+
+import { toRpcException } from './rpc.utils';
+
+describe('toRpcException', () => {
+  it('should convert HttpException preserving status code and response body', () => {
+    const httpError = new BadRequestException('invalid');
+
+    const rpcException = toRpcException(httpError);
+
+    expect(rpcException).toBeInstanceOf(RpcException);
+    expect(rpcException.getError()).toMatchObject({
+      statusCode: HttpStatus.BAD_REQUEST,
+      message: 'invalid',
+    });
+  });
+
+  it('should ensure status code is present when HttpException response omits it', () => {
+    const httpError = new HttpException({ message: 'missing status' }, HttpStatus.FORBIDDEN);
+
+    const rpcException = toRpcException(httpError);
+
+    expect(rpcException.getError()).toMatchObject({
+      statusCode: HttpStatus.FORBIDDEN,
+      message: 'missing status',
+    });
+  });
+
+  it('should handle string responses from HttpException', () => {
+    class CustomHttpException extends HttpException {
+      constructor() {
+        super('custom-error', HttpStatus.NOT_FOUND);
+      }
+    }
+
+    const rpcException = toRpcException(new CustomHttpException());
+
+    expect(rpcException.getError()).toEqual({
+      statusCode: HttpStatus.NOT_FOUND,
+      message: 'custom-error',
+    });
+  });
+});

--- a/apps/notifications/src/common/rpc.utils.ts
+++ b/apps/notifications/src/common/rpc.utils.ts
@@ -32,9 +32,28 @@ export function toRpcException(error: unknown): RpcException {
   }
 
   if (error instanceof HttpException) {
+    const status = error.getStatus();
+    const response = error.getResponse();
+
+    if (typeof response === 'object' && response !== null) {
+      const payload = response as Record<string, unknown>;
+      const statusCodeCandidate = payload['statusCode'];
+      const statusCode =
+        typeof statusCodeCandidate === 'number'
+          ? statusCodeCandidate
+          : typeof statusCodeCandidate === 'string'
+            ? Number.parseInt(statusCodeCandidate, 10) || status
+            : status;
+
+      return new RpcException({
+        statusCode,
+        ...payload,
+      });
+    }
+
     return new RpcException({
-      status: error.getStatus(),
-      response: error.getResponse(),
+      statusCode: status,
+      message: response,
     });
   }
 

--- a/apps/tasks/src/common/rpc.utils.spec.ts
+++ b/apps/tasks/src/common/rpc.utils.spec.ts
@@ -1,0 +1,29 @@
+import { BadRequestException, HttpException, HttpStatus } from '@nestjs/common';
+import { RpcException } from '@nestjs/microservices';
+
+import { toRpcException } from './rpc.utils';
+
+describe('toRpcException', () => {
+  it('should wrap HttpException with consistent payload', () => {
+    const httpError = new BadRequestException('invalid');
+
+    const rpcException = toRpcException(httpError);
+
+    expect(rpcException).toBeInstanceOf(RpcException);
+    expect(rpcException.getError()).toMatchObject({
+      statusCode: HttpStatus.BAD_REQUEST,
+      message: 'invalid',
+    });
+  });
+
+  it('should fallback to HttpException status when payload lacks status code', () => {
+    const httpError = new HttpException({ error: 'denied' }, HttpStatus.FORBIDDEN);
+
+    const rpcException = toRpcException(httpError);
+
+    expect(rpcException.getError()).toMatchObject({
+      statusCode: HttpStatus.FORBIDDEN,
+      error: 'denied',
+    });
+  });
+});

--- a/apps/tasks/src/common/rpc.utils.ts
+++ b/apps/tasks/src/common/rpc.utils.ts
@@ -32,9 +32,28 @@ export function toRpcException(error: unknown): RpcException {
   }
 
   if (error instanceof HttpException) {
+    const status = error.getStatus();
+    const response = error.getResponse();
+
+    if (typeof response === 'object' && response !== null) {
+      const payload = response as Record<string, unknown>;
+      const statusCodeCandidate = payload['statusCode'];
+      const statusCode =
+        typeof statusCodeCandidate === 'number'
+          ? statusCodeCandidate
+          : typeof statusCodeCandidate === 'string'
+            ? Number.parseInt(statusCodeCandidate, 10) || status
+            : status;
+
+      return new RpcException({
+        statusCode,
+        ...payload,
+      });
+    }
+
     return new RpcException({
-      status: error.getStatus(),
-      response: error.getResponse(),
+      statusCode: status,
+      message: response,
     });
   }
 


### PR DESCRIPTION
## Summary
- ensure notifications and tasks RPC utilities keep HttpException status codes when building RpcExceptions
- add unit tests covering the HttpException conversion edge cases for both services

## Testing
- `pnpm --filter @apps/notifications-service test -- --runTestsByPath src/common/rpc.utils.spec.ts`
- `pnpm --filter @apps/tasks-service test -- --runTestsByPath src/common/rpc.utils.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_68e7787fb7e0832b8ae66c1a1ed3911f