### PR TITLE
Fix notifications RPC failures by configuring RabbitMQ URL

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,6 +90,7 @@ services:
       PORT: ${API_PORT:-3001}
       AUTH_SERVICE_HOST: auth-service
       AUTH_SERVICE_PORT: 4010
+      RABBITMQ_URL: amqp://${RABBITMQ_USER:-admin}:${RABBITMQ_PASS:-admin}@rabbitmq:5672
       CORS_ORIGIN: ${CORS_ORIGIN:-http://localhost:3000}
     depends_on:
       db:


### PR DESCRIPTION
## Summary
- configure the api-gateway Docker Compose service with the RabbitMQ host URL so RPC calls reach the broker when running in containers

## Testing
- not run (configuration change)


------
https://chatgpt.com/codex/tasks/task_e_68e77a6f873c832ba16f2e3c23898be7