### PR TITLE
Fix notifications RPC handler registration

### DIFF
--- a/apps/api/src/notifications/notifications.service.ts
+++ b/apps/api/src/notifications/notifications.service.ts
@@ -6,6 +6,7 @@ import {
   HttpStatus,
   Inject,
   Injectable,
+  Logger,
   NotFoundException,
   UnauthorizedException,
   UnprocessableEntityException,
@@ -28,6 +29,8 @@ export type PaginatedNotificationResult = PaginatedNotifications;
 
 @Injectable()
 export class NotificationsService {
+  private readonly logger = new Logger(NotificationsService.name);
+
   constructor(
     @Inject(NOTIFICATIONS_RPC_CLIENT)
     private readonly client: ClientProxy,
@@ -53,9 +56,12 @@ export class NotificationsService {
     payload: unknown,
   ): Promise<TResponse> {
     try {
+      this.logger.debug(`📤 Sending RPC request (pattern=${pattern})`);
       return await lastValueFrom(this.client.send<TResponse>(pattern, payload));
     } catch (error) {
       throw this.toHttpException(error);
+    } finally {
+      this.logger.debug(`📥 Completed RPC request (pattern=${pattern})`);
     }
   }
 

--- a/apps/notifications/src/app.module.ts
+++ b/apps/notifications/src/app.module.ts
@@ -8,6 +8,7 @@ import {
   NOTIFICATIONS_GATEWAY_QUEUE,
 } from './notifications.constants';
 import { HealthModule } from './health/health.module';
+import { NotificationsController } from './notifications.controller';
 import { NotificationsService } from './notifications.service';
 import { Notification } from './notifications/notification.entity';
 import { NotificationsPersistenceModule } from './notifications/persistence/notifications-persistence.module';
@@ -70,6 +71,7 @@ const validateEnv = (config: Record<string, unknown>) => {
     HealthModule,
     NotificationsPersistenceModule,
   ],
+  controllers: [NotificationsController],
   providers: [NotificationsService],
 })
 export class AppModule {}

--- a/apps/notifications/src/notifications.controller.ts
+++ b/apps/notifications/src/notifications.controller.ts
@@ -1,0 +1,64 @@
+import { Controller } from '@nestjs/common';
+import { Ctx, EventPattern, MessagePattern, Payload, RmqContext } from '@nestjs/microservices';
+import { AppLoggerService } from '@repo/logger';
+import type {
+  PaginatedNotifications,
+  TaskCommentCreatedPayload,
+  TaskUpdatedForwardPayload,
+} from '@repo/types';
+
+import {
+  NOTIFICATIONS_MESSAGE_PATTERNS,
+  TASKS_COMMENT_CREATED_PATTERN,
+  TASKS_UPDATED_PATTERN,
+} from './notifications.constants';
+import { NotificationsService } from './notifications.service';
+
+@Controller()
+export class NotificationsController {
+  private readonly logger: AppLoggerService;
+
+  constructor(
+    private readonly notificationsService: NotificationsService,
+    appLogger: AppLoggerService,
+  ) {
+    this.logger = appLogger.withContext({
+      context: NotificationsController.name,
+    });
+  }
+
+  @MessagePattern(NOTIFICATIONS_MESSAGE_PATTERNS.FIND_ALL)
+  async handleFindAll(
+    @Payload() payload: unknown,
+    @Ctx() context: RmqContext,
+  ): Promise<PaginatedNotifications> {
+    this.logger.debug(
+      `📥 Received RPC pattern ${NOTIFICATIONS_MESSAGE_PATTERNS.FIND_ALL}`,
+    );
+    const response = await this.notificationsService.findAll(payload, context);
+    this.logger.debug(
+      `📤 Responding to RPC pattern ${NOTIFICATIONS_MESSAGE_PATTERNS.FIND_ALL}`,
+    );
+    return response;
+  }
+
+  @EventPattern(TASKS_COMMENT_CREATED_PATTERN)
+  async handleNewComment(
+    @Payload() payload: TaskCommentCreatedPayload,
+    @Ctx() context: RmqContext,
+  ): Promise<void> {
+    this.logger.debug(
+      `📥 Received event pattern ${TASKS_COMMENT_CREATED_PATTERN}`,
+    );
+    await this.notificationsService.handleNewComment(payload, context);
+  }
+
+  @EventPattern(TASKS_UPDATED_PATTERN)
+  async handleTaskUpdated(
+    @Payload() payload: TaskUpdatedForwardPayload,
+    @Ctx() context: RmqContext,
+  ): Promise<void> {
+    this.logger.debug(`📥 Received event pattern ${TASKS_UPDATED_PATTERN}`);
+    await this.notificationsService.handleTaskUpdated(payload, context);
+  }
+}

--- a/apps/notifications/src/notifications.service.ts
+++ b/apps/notifications/src/notifications.service.ts
@@ -1,17 +1,8 @@
 import { Inject, Injectable } from '@nestjs/common';
-import {
-  Ctx,
-  EventPattern,
-  MessagePattern,
-  Payload,
-  RmqContext,
-  RmqRecord,
-  RmqRecordBuilder,
-} from '@nestjs/microservices';
+import { RmqContext, RmqRecord, RmqRecordBuilder } from '@nestjs/microservices';
 import {
   ListNotificationsPayloadDto,
   NOTIFICATION_CHANNELS,
-  NOTIFICATIONS_MESSAGE_PATTERNS,
   type NotificationChannel,
   type NotificationDTO,
   type PaginatedNotifications,
@@ -76,11 +67,7 @@ export class NotificationsService {
     this.logger = appLogger.withContext({ context: NotificationsService.name });
   }
 
-  @MessagePattern(NOTIFICATIONS_MESSAGE_PATTERNS.FIND_ALL)
-  async findAll(
-    @Payload() payload: unknown,
-    @Ctx() context: RmqContext,
-  ): Promise<PaginatedNotifications> {
+  async findAll(payload: unknown, context: RmqContext): Promise<PaginatedNotifications> {
     try {
       const dto = transformPayload(ListNotificationsPayloadDto, payload ?? {});
       const requestId = this.resolveRequestId(dto, context);
@@ -103,10 +90,9 @@ export class NotificationsService {
     }
   }
 
-  @EventPattern(TASKS_COMMENT_CREATED_PATTERN)
   async handleNewComment(
-    @Payload() payload: TaskCommentCreatedPayload,
-    @Ctx() context: RmqContext,
+    payload: TaskCommentCreatedPayload,
+    context: RmqContext,
   ): Promise<void> {
     const channelRef = context.getChannelRef() as unknown;
     const messageRef = context.getMessage() as unknown;
@@ -172,10 +158,9 @@ export class NotificationsService {
     });
   }
 
-  @EventPattern(TASKS_UPDATED_PATTERN)
   async handleTaskUpdated(
-    @Payload() payload: TaskUpdatedForwardPayload,
-    @Ctx() context: RmqContext,
+    payload: TaskUpdatedForwardPayload,
+    context: RmqContext,
   ): Promise<void> {
     const channelRef = context.getChannelRef() as unknown;
     const messageRef = context.getMessage() as unknown;


### PR DESCRIPTION
## Summary
- add a dedicated notifications controller so RPC and event patterns are registered with the microservice
- keep the service focused on business logic while adding debug logs for RabbitMQ handlers
- log RPC calls from the API gateway to aid troubleshooting of the notifications client

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e780b7c8b0832b95020bdfe68c5e2e