### PR TITLE
Add responsible info to notification cards

### DIFF
--- a/apps/web/src/features/notifications/components/NotificationsPopover.tsx
+++ b/apps/web/src/features/notifications/components/NotificationsPopover.tsx
@@ -9,6 +9,7 @@ import { cn } from '@/lib/utils'
 import { router } from '@/router'
 
 import { getNotifications } from '../api/getNotifications'
+import { getNotificationResponsibleName } from '../utils/getNotificationResponsibleName'
 
 const REFRESH_INTERVAL_MS = 60_000
 const DEFAULT_LIMIT = 10
@@ -193,6 +194,8 @@ export function NotificationsPopover({ className }: NotificationsPopoverProps) {
             <ul className="divide-y divide-border">
               {notifications.map((notification) => {
                 const taskId = getTaskIdFromMetadata(notification)
+                const responsibleName =
+                  getNotificationResponsibleName(notification)
 
                 return (
                   <li key={notification.id} className="space-y-2 px-4 py-3 text-sm">
@@ -204,6 +207,15 @@ export function NotificationsPopover({ className }: NotificationsPopoverProps) {
                         {formatChannel(notification.channel)}
                       </span>
                     </div>
+
+                    {responsibleName ? (
+                      <p className="text-xs text-muted-foreground">
+                        Responsável:{' '}
+                        <span className="font-medium text-foreground">
+                          {responsibleName}
+                        </span>
+                      </p>
+                    ) : null}
 
                     <div className="flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
                       <span>{formatDateTime(notification.createdAt)}</span>

--- a/apps/web/src/features/notifications/utils/getNotificationResponsibleName.ts
+++ b/apps/web/src/features/notifications/utils/getNotificationResponsibleName.ts
@@ -1,0 +1,44 @@
+import type { NotificationDTO } from '@repo/types'
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+function getTrimmedValue(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null
+  }
+
+  const trimmed = value.trim()
+
+  return trimmed.length > 0 ? trimmed : null
+}
+
+export function getNotificationResponsibleName(
+  notification: NotificationDTO,
+): string | null {
+  const metadata = notification.metadata
+
+  if (!isRecord(metadata)) {
+    return null
+  }
+
+  const metadataCandidates: Array<string | null> = []
+
+  const commentAuthorName = getTrimmedValue(metadata['commentAuthorName'])
+  const actorDisplayName = getTrimmedValue(metadata['actorDisplayName'])
+
+  metadataCandidates.push(commentAuthorName, actorDisplayName)
+
+  if (isRecord(metadata['actor'])) {
+    metadataCandidates.push(getTrimmedValue(metadata['actor']['displayName']))
+  }
+
+  for (const candidate of metadataCandidates) {
+    if (candidate) {
+      return candidate
+    }
+  }
+
+  return null
+}

--- a/apps/web/src/features/tasks/pages/TaskDetailsPage.tsx
+++ b/apps/web/src/features/tasks/pages/TaskDetailsPage.tsx
@@ -37,6 +37,7 @@ import {
   commentFormSchema,
   type CommentFormSchema,
 } from '../schemas/commentSchema'
+import { getNotificationResponsibleName } from '../../notifications/utils/getNotificationResponsibleName'
 
 interface TaskDetailsPageProps {
   taskId: string
@@ -523,24 +524,43 @@ export function TaskDetailsPage({ taskId }: TaskDetailsPageProps) {
             <p className="text-sm text-destructive">{notificationsError}</p>
           ) : notifications.length > 0 ? (
             <ul className="space-y-4">
-              {notifications.map((notification: NotificationDTO) => (
-                <li key={notification.id} className="rounded-md border border-border bg-background/80 p-4">
-                  <div className="flex items-center justify-between text-xs text-muted-foreground">
-                    <span>Canal: {notification.channel}</span>
-                    <span>Status: {notification.status}</span>
-                  </div>
-                  <p className="mt-2 text-sm text-foreground">{notification.message}</p>
-                  <div className="mt-3 flex flex-wrap gap-4 text-xs text-muted-foreground">
-                    <span>Criada: {formatDateTime(notification.createdAt)}</span>
-                    <span>
-                      Enviada:{' '}
-                      {notification.sentAt
-                        ? formatDateTime(notification.sentAt)
-                        : 'Não enviada'}
-                    </span>
-                  </div>
-                </li>
-              ))}
+              {notifications.map((notification: NotificationDTO) => {
+                const responsibleName =
+                  getNotificationResponsibleName(notification) ?? 'Não informado'
+
+                return (
+                  <li
+                    key={notification.id}
+                    className="rounded-md border border-border bg-background/80 p-4"
+                  >
+                    <div className="flex flex-wrap items-center justify-between gap-2 text-xs text-muted-foreground">
+                      <span>
+                        Responsável:{' '}
+                        <span className="font-medium text-foreground">
+                          {responsibleName}
+                        </span>
+                      </span>
+                      <span>
+                        Criada em:{' '}
+                        <span className="font-medium text-foreground">
+                          {formatDateTime(notification.createdAt)}
+                        </span>
+                      </span>
+                    </div>
+                    <p className="mt-2 text-sm text-foreground">{notification.message}</p>
+                    <div className="mt-3 flex flex-wrap gap-4 text-xs text-muted-foreground">
+                      <span>Canal: {notification.channel}</span>
+                      <span>Status: {notification.status}</span>
+                      <span>
+                        Enviada:{' '}
+                        {notification.sentAt
+                          ? formatDateTime(notification.sentAt)
+                          : 'Não enviada'}
+                      </span>
+                    </div>
+                  </li>
+                )
+              })}
             </ul>
           ) : (
             <p className="text-sm text-muted-foreground">


### PR DESCRIPTION
## Summary
- add a shared helper to extract the responsible person name from notification metadata
- show the responsible name and creation timestamp on notification cards and the notifications popover

## Testing
- pnpm --filter web test

------
https://chatgpt.com/codex/tasks/task_e_68e787c3a18c832b8c11515d7267ef87