### PR TITLE
Prevent self-authored notifications from being persisted

### DIFF
--- a/apps/notifications/src/notifications.service.ts
+++ b/apps/notifications/src/notifications.service.ts
@@ -532,6 +532,11 @@ export class NotificationsService {
       }
     }
 
+    const authorId = this.extractIdentifier(payload?.comment?.authorId);
+    if (authorId) {
+      recipients.delete(authorId);
+    }
+
     return Array.from(recipients);
   }
 
@@ -545,6 +550,14 @@ export class NotificationsService {
     const taskRecipients = this.extractTaskRecipients(payload?.task);
     for (const recipient of taskRecipients) {
       recipients.add(recipient);
+    }
+
+    const actorId =
+      this.extractIdentifier(payload?.actor?.id) ??
+      this.extractIdentifier((payload as { actorId?: unknown }).actorId);
+
+    if (actorId) {
+      recipients.delete(actorId);
     }
 
     return Array.from(recipients);


### PR DESCRIPTION
## Summary
- ensure the notifications service filters out comment authors and task actors from recipient lists
- expand unit test coverage to confirm authors and actors never receive their own notifications

## Testing
- pnpm --filter @apps/notifications-service test

------
https://chatgpt.com/codex/tasks/task_e_68e78a1c211c832ba6f50b6ee772edb4