### PR TITLE
feat: add runtime docker stages and compose profiles

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -13,3 +13,20 @@ COPY package.json pnpm-lock.yaml pnpm-workspace.yaml turbo.json ./
 COPY packages ./packages
 COPY apps/api ./apps/api
 CMD ["pnpm", "--filter", "@apps/api-gateway...", "dev"]
+
+FROM base AS build
+ENV NODE_ENV=development
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml turbo.json ./
+COPY packages ./packages
+COPY apps/api ./apps/api
+RUN pnpm install --filter @apps/api-gateway... --frozen-lockfile
+RUN pnpm --filter @apps/api-gateway... build
+RUN pnpm deploy --filter @apps/api-gateway --prod /workspace/deploy
+
+FROM node:22-alpine AS runtime
+WORKDIR /app
+ENV NODE_ENV=production
+COPY --from=build /workspace/deploy/ ./
+RUN rm -rf src test Dockerfile README.md eslint.config.mjs tsconfig.json tsconfig.build.json nest-cli.json || true
+EXPOSE 3001
+CMD ["node", "dist/main.js"]

--- a/apps/auth/Dockerfile
+++ b/apps/auth/Dockerfile
@@ -13,3 +13,20 @@ COPY package.json pnpm-lock.yaml pnpm-workspace.yaml turbo.json ./
 COPY packages ./packages
 COPY apps/auth ./apps/auth
 CMD ["pnpm", "--filter", "@apps/auth-service...", "dev"]
+
+FROM base AS build
+ENV NODE_ENV=development
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml turbo.json ./
+COPY packages ./packages
+COPY apps/auth ./apps/auth
+RUN pnpm install --filter @apps/auth-service... --frozen-lockfile
+RUN pnpm --filter @apps/auth-service... build
+RUN pnpm deploy --filter @apps/auth-service --prod /workspace/deploy
+
+FROM node:22-alpine AS runtime
+WORKDIR /app
+ENV NODE_ENV=production
+COPY --from=build /workspace/deploy/ ./
+RUN rm -rf src test Dockerfile README.md eslint.config.mjs tsconfig.json tsconfig.build.json || true
+EXPOSE 4010
+CMD ["node", "dist/main.js"]

--- a/apps/notifications/Dockerfile
+++ b/apps/notifications/Dockerfile
@@ -13,3 +13,20 @@ COPY package.json pnpm-lock.yaml pnpm-workspace.yaml turbo.json ./
 COPY packages ./packages
 COPY apps/notifications ./apps/notifications
 CMD ["pnpm", "--filter", "@apps/notifications-service...", "dev"]
+
+FROM base AS build
+ENV NODE_ENV=development
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml turbo.json ./
+COPY packages ./packages
+COPY apps/notifications ./apps/notifications
+RUN pnpm install --filter @apps/notifications-service... --frozen-lockfile
+RUN pnpm --filter @apps/notifications-service... build
+RUN pnpm deploy --filter @apps/notifications-service --prod /workspace/deploy
+
+FROM node:22-alpine AS runtime
+WORKDIR /app
+ENV NODE_ENV=production
+COPY --from=build /workspace/deploy/ ./
+RUN rm -rf src test Dockerfile README.md eslint.config.mjs tsconfig.json tsconfig.build.json || true
+EXPOSE 3005
+CMD ["node", "dist/main.js"]

--- a/apps/tasks/Dockerfile
+++ b/apps/tasks/Dockerfile
@@ -13,3 +13,20 @@ COPY package.json pnpm-lock.yaml pnpm-workspace.yaml turbo.json ./
 COPY packages ./packages
 COPY apps/tasks ./apps/tasks
 CMD ["pnpm", "--filter", "@apps/tasks-service...", "dev"]
+
+FROM base AS build
+ENV NODE_ENV=development
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml turbo.json ./
+COPY packages ./packages
+COPY apps/tasks ./apps/tasks
+RUN pnpm install --filter @apps/tasks-service... --frozen-lockfile
+RUN pnpm --filter @apps/tasks-service... build
+RUN pnpm deploy --filter @apps/tasks-service --prod /workspace/deploy
+
+FROM node:22-alpine AS runtime
+WORKDIR /app
+ENV NODE_ENV=production
+COPY --from=build /workspace/deploy/ ./
+RUN rm -rf src test Dockerfile README.md eslint.config.mjs tsconfig.json tsconfig.build.json || true
+EXPOSE 3003
+CMD ["node", "dist/main.js"]

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -13,3 +13,19 @@ COPY package.json pnpm-lock.yaml pnpm-workspace.yaml turbo.json ./
 COPY packages ./packages
 COPY apps/web ./apps/web
 CMD ["pnpm", "--filter", "@apps/web...", "dev"]
+
+FROM base AS build
+ARG NEXT_PUBLIC_API_URL="http://localhost:3001/api"
+ENV NODE_ENV=production
+ENV NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml turbo.json ./
+COPY packages ./packages
+COPY apps/web ./apps/web
+RUN pnpm install --filter @apps/web... --frozen-lockfile
+RUN pnpm --filter @apps/web... build
+
+FROM nginx:1.27-alpine AS runtime
+COPY apps/web/nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /workspace/apps/web/dist/ /usr/share/nginx/html/
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/apps/web/nginx.conf
+++ b/apps/web/nginx.conf
@@ -1,0 +1,16 @@
+server {
+  listen 80;
+  server_name _;
+  root /usr/share/nginx/html;
+  include /etc/nginx/mime.types;
+  charset utf-8;
+
+  location / {
+    try_files $uri $uri/ /index.html;
+  }
+
+  location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf)$ {
+    expires 7d;
+    add_header Cache-Control "public, max-age=604800, immutable";
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,11 @@
 # docker-compose.yml
-# 🐋 JungleGaming Full-stack Challenge — Ambiente de Desenvolvimento
+# 🐋 JungleGaming Full-stack Challenge — Ambiente de Desenvolvimento e Produção Lite
 # Stack: NestJS microservices + RabbitMQ + PostgreSQL + React (TanStack Router)
 
 services:
   # 🗄️ Banco de dados Postgres
   db:
+    profiles: ["dev", "prod-lite"]
     image: postgres:17.5-alpine3.21
     container_name: db-challenge-jungle-gaming
     restart: unless-stopped
@@ -26,6 +27,7 @@ services:
 
   # 🐇 Broker de Mensagens RabbitMQ
   rabbitmq:
+    profiles: ["dev", "prod-lite"]
     image: rabbitmq:3.13-management-alpine
     container_name: rabbitmq-challenge-jungle-gaming
     restart: unless-stopped
@@ -45,8 +47,9 @@ services:
       timeout: 5s
       retries: 5
 
-  # 🔐 Serviço de Autenticação
+  # 🔐 Serviço de Autenticação — Desenvolvimento
   auth-service:
+    profiles: ["dev"]
     build:
       context: .
       dockerfile: apps/auth/Dockerfile
@@ -75,8 +78,32 @@ services:
     networks:
       - challenge-network
 
-  # ⚙️ API Gateway
+  # 🔐 Serviço de Autenticação — Produção Lite
+  auth-service-lite:
+    profiles: ["prod-lite"]
+    build:
+      context: .
+      dockerfile: apps/auth/Dockerfile
+      target: runtime
+    container_name: auth-service-lite
+    environment:
+      NODE_ENV: production
+      AUTH_SERVICE_PORT: ${AUTH_SERVICE_PORT:-4010}
+      DATABASE_URL: postgres://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-password}@db:5432/${POSTGRES_DB:-challenge_db}
+      JWT_SECRET: ${JWT_SECRET:-supersecret}
+      JWT_EXPIRES_IN: ${JWT_EXPIRES_IN:-15m}
+      BCRYPT_SALT_ROUNDS: ${BCRYPT_SALT_ROUNDS:-10}
+    depends_on:
+      db:
+        condition: service_healthy
+    ports:
+      - "${AUTH_SERVICE_PORT:-4010}:4010"
+    networks:
+      - challenge-network
+
+  # ⚙️ API Gateway — Desenvolvimento
   api-gateway:
+    profiles: ["dev"]
     build:
       context: .
       dockerfile: apps/api/Dockerfile
@@ -107,8 +134,34 @@ services:
     networks:
       - challenge-network
 
-  # 🧩 Serviço de Tarefas
+  # ⚙️ API Gateway — Produção Lite
+  api-gateway-lite:
+    profiles: ["prod-lite"]
+    build:
+      context: .
+      dockerfile: apps/api/Dockerfile
+      target: runtime
+    container_name: api-gateway-lite
+    environment:
+      NODE_ENV: production
+      PORT: ${API_PORT:-3001}
+      AUTH_SERVICE_HOST: auth-service-lite
+      AUTH_SERVICE_PORT: 4010
+      RABBITMQ_URL: amqp://${RABBITMQ_USER:-admin}:${RABBITMQ_PASS:-admin}@rabbitmq:5672
+      CORS_ORIGIN: ${CORS_ORIGIN:-http://localhost:3000}
+    depends_on:
+      db:
+        condition: service_healthy
+      auth-service-lite:
+        condition: service_started
+    ports:
+      - "${API_PORT:-3001}:3001"
+    networks:
+      - challenge-network
+
+  # 🧩 Serviço de Tarefas — Desenvolvimento
   tasks-service:
+    profiles: ["dev"]
     build:
       context: .
       dockerfile: apps/tasks/Dockerfile
@@ -138,8 +191,33 @@ services:
     networks:
       - challenge-network
 
-  # 🔔 Serviço de Notificações
+  # 🧩 Serviço de Tarefas — Produção Lite
+  tasks-service-lite:
+    profiles: ["prod-lite"]
+    build:
+      context: .
+      dockerfile: apps/tasks/Dockerfile
+      target: runtime
+    container_name: tasks-service-lite
+    environment:
+      NODE_ENV: production
+      PORT: ${TASKS_PORT:-3003}
+      DATABASE_URL: postgres://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-password}@db:5432/${POSTGRES_DB:-challenge_db}
+      RABBITMQ_URL: amqp://${RABBITMQ_USER:-admin}:${RABBITMQ_PASS:-admin}@rabbitmq:5672
+      CORS_ORIGIN: ${CORS_ORIGIN:-http://localhost:3000}
+    depends_on:
+      db:
+        condition: service_healthy
+      rabbitmq:
+        condition: service_healthy
+    ports:
+      - "${TASKS_PORT:-3003}:3003"
+    networks:
+      - challenge-network
+
+  # 🔔 Serviço de Notificações — Desenvolvimento
   notifications-service:
+    profiles: ["dev"]
     build:
       context: .
       dockerfile: apps/notifications/Dockerfile
@@ -169,8 +247,33 @@ services:
     networks:
       - challenge-network
 
-  # 🌐 Front-end React (TanStack Router + shadcn/ui)
+  # 🔔 Serviço de Notificações — Produção Lite
+  notifications-service-lite:
+    profiles: ["prod-lite"]
+    build:
+      context: .
+      dockerfile: apps/notifications/Dockerfile
+      target: runtime
+    container_name: notifications-service-lite
+    environment:
+      NODE_ENV: production
+      PORT: ${NOTIFICATIONS_PORT:-3005}
+      DATABASE_URL: postgres://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-password}@db:5432/${POSTGRES_DB:-challenge_db}
+      RABBITMQ_URL: amqp://${RABBITMQ_USER:-admin}:${RABBITMQ_PASS:-admin}@rabbitmq:5672
+      CORS_ORIGIN: ${CORS_ORIGIN:-http://localhost:3000}
+    depends_on:
+      db:
+        condition: service_healthy
+      rabbitmq:
+        condition: service_healthy
+    ports:
+      - "${NOTIFICATIONS_PORT:-3005}:3005"
+    networks:
+      - challenge-network
+
+  # 🌐 Front-end React (TanStack Router + shadcn/ui) — Desenvolvimento
   web:
+    profiles: ["dev"]
     build:
       context: .
       dockerfile: apps/web/Dockerfile
@@ -193,6 +296,24 @@ services:
       - pnpm-store:/pnpm/store
       - root-node-modules:/workspace/node_modules
       - web-node-modules:/workspace/apps/web/node_modules
+    networks:
+      - challenge-network
+
+  # 🌐 Front-end React — Produção Lite
+  web-lite:
+    profiles: ["prod-lite"]
+    build:
+      context: .
+      dockerfile: apps/web/Dockerfile
+      target: runtime
+      args:
+        NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-http://localhost:3001/api}
+    container_name: web-app-lite
+    depends_on:
+      api-gateway-lite:
+        condition: service_started
+    ports:
+      - "${WEB_PORT:-3000}:80"
     networks:
       - challenge-network
 


### PR DESCRIPTION
## Summary
- add runtime stages to all service Dockerfiles and prune build artifacts for lean runtime images
- serve the web app build through nginx with configurable API endpoint
- split docker-compose into dev and prod-lite profiles to toggle between developer and runtime containers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e798b38f80832ba084733ce136b2e3